### PR TITLE
Replace bitwise constexprs with numeric literals in compiler

### DIFF
--- a/lib/compiler.psl
+++ b/lib/compiler.psl
@@ -1810,7 +1810,7 @@ class PSC::Translate is
                //  Null value for this type is same as that for
                //  Univ_Integer, which is the most-negative value
                //  (- 2**63)
-               TLO |= Gets | " = bitcast i64 shl(i64 1, i64 63) to i64"
+               TLO |= Gets | " = bitcast i64 -9223372036854775808 to i64"
             else
                //  Just represent null value of type as an integer
                TLO |= Gets | " = bitcast i64 `(Null_Val) to i64"
@@ -1965,7 +1965,7 @@ class PSC::Translate is
                //  Univ_Integer then we use the most-negative value
                //  which = 1 << 63
                const Null_Val_Str := (Null_Val is null?
-                                        "shl (i64 1, i64 63)":
+                                        "-9223372036854775808":
                                         To_String(Null_Val))
 
                TLO |= Result_Bit | " = icmp `(Eq_Or_Ne) i64 " | Arg |

--- a/lib/type_desc_llvm_utils.psl
+++ b/lib/type_desc_llvm_utils.psl
@@ -39,7 +39,7 @@ class PSC::Type_Desc_LLVM_Utils is
    //     a region*2, + 1 (so it is odd)
 
    //  Masks, etc. for picking apart a "special" large object
-   const High_And_Low_Bit := "or (i64 shl (i64 1, i64 63), i64 1)"
+   const High_And_Low_Bit := "-9223372036854775807" // (1 << 63) | 1
    const Chunk_Shift_Amount := 32;
    const Str_Shift_Amount := Chunk_Shift_Amount;
    const Chunk_Divisor := 2**Chunk_Shift_Amount;


### PR DESCRIPTION
Modern LLVM IR no longer supports bitwise const expressions ([or](https://github.com/llvm/llvm-project/commit/625113402f9febd4d8c907a342ea09a3c0982ba8#diff-100c1b4a714c7d260fc41ac27cc8d2d5857d54021f16d73debc71125d110e7daR3861) and [shl](https://github.com/llvm-project-tlp/llvm-project/commit/e23f5206d5a2a129aeb4354053ee3ec76168e351#diff-100c1b4a714c7d260fc41ac27cc8d2d5857d54021f16d73debc71125d110e7daR4161) in this case). This causes the compiler to break with current versions of llc. This commit replaces these constant expressions with their equivalent numeric literals.