### PR TITLE
[Reflection] Add Decl and Is_Var to Component_Info

### DIFF
--- a/interpreter/psc-interpreter.ads
+++ b/interpreter/psc-interpreter.ads
@@ -1962,6 +1962,8 @@ package PSC.Interpreter is
       Type_Desc   : Type_Descriptor_Ptr;
       Is_By_Ref   : Boolean := False;
       Is_Optional : Boolean := True;
+      Is_Var      : Boolean := False;
+      Decl     : Trees.Optional_Tree := Trees.Null_Optional_Tree;
    end record;
    type Component_Info_Array is array (Positive range <>) of Component_Info;
    type Component_Info_Array_Ptr is access all Component_Info_Array;

--- a/lib/reflection.psi
+++ b/lib/reflection.psi
@@ -813,9 +813,11 @@ interface PSC::Reflection<> is
     end interface Const_Info
 
     interface Component_Info<> is
-        const Type_Desc   : Type_Descriptor
-        const Is_By_Ref   : Boolean
-        const Is_Optional : Boolean
+        const Type_Desc      : Type_Descriptor
+        const Is_By_Ref      : Boolean
+        const Is_Optional    : Boolean
+        const Is_Var         : Boolean
+        const Component_Decl : Decl
     end interface Component_Info
 
     interface Routine_Info<> is

--- a/semantics/psc-trees-semantics-dynamic.adb
+++ b/semantics/psc-trees-semantics-dynamic.adb
@@ -5570,6 +5570,9 @@ package body PSC.Trees.Semantics.Dynamic is
                Comp_Is_By_Ref : constant Boolean :=
                  Comp_Sem.Associated_Symbol /= null
                 and then Static.Sym_Is_By_Ref (Comp_Sem.Associated_Symbol);
+               Comp_Is_Var : constant Boolean :=
+                  Comp_Sem.Associated_Symbol /= null
+                and then Static.Sym_Is_Variable (Comp_Sem.Associated_Symbol);
             begin
                if Obj_Type.All_Parameters_Known then
                   --  Substitute into formal type
@@ -5612,10 +5615,12 @@ package body PSC.Trees.Semantics.Dynamic is
                end if;
 
                Type_Desc.Components (I).Is_By_Ref := Comp_Is_By_Ref;
+               Type_Desc.Components (I).Is_Var := Comp_Is_Var;
                Type_Desc.Components (I).Is_Optional :=
                  Comp_Actual_Type.Value_Is_Optional;
                    --  TBD: Should we "or" with
                    --       Comp_Formal_Type.Value_Is_Optional?
+               Type_Desc.Components (I).Decl := Comp_Tree;
                if Comp_Formal_Type.Known_To_Be_Assignable
                  and then not Comp_Is_By_Ref
                  and then not Comp_Actual_Type.Known_To_Be_Assignable
@@ -6772,7 +6777,9 @@ package body PSC.Trees.Semantics.Dynamic is
                  new Component_Info_Array'(1 =>
                    (Type_Desc => Underlying_Type_Desc,
                     Is_By_Ref => False,
-                    Is_Optional => True)),  --  TBD: can it be null?
+                    Is_Optional => True,
+                    Is_Var => True,
+                    Decl => Underlying_Type_Desc.Type_Sem.Definition)),  --  TBD: can it be null?
                Num_Nested_Types => Ancestors'Length,
                Nested_Types => Ancestors,
                Num_Nested_Objs => 0,

--- a/semantics/psc-trees-semantics-translator.adb
+++ b/semantics/psc-trees-semantics-translator.adb
@@ -4944,6 +4944,16 @@ package body PSC.Trees.Semantics.Translator is
                   Store_Word (Result +
                     Large_Obj_Header_Size + Offset_Within_Area'(2),
                     Boolean'Pos (Comp_Info.Is_Optional));
+
+                  --  Set the "Is_Var" field
+                  Store_Word (Result +
+                    Large_Obj_Header_Size + Offset_Within_Area'(3),
+                    Boolean'Pos (Comp_Info.Is_Var));
+
+                  --  Fill in the "Component_Decl" field
+                  Store_Word (Result +
+                    Large_Obj_Header_Size + Offset_Within_Area'(4),
+                     To_Word_Type (Sem_Info (Comp_Info.Decl)));
                end;
 
             when Nested_Types_Kind =>


### PR DESCRIPTION
This pull request adds `Is_Var` and `Component_Decl` to the `Component_Info` type. These two properties function identically to the `Is_Var` and `Param_Decl` properties in `Routine_Param_Info`. 