### PR TITLE
[Reflection] Add more data to Tree library

### DIFF
--- a/lib/reflection.psi
+++ b/lib/reflection.psi
@@ -142,6 +142,8 @@ interface PSC::Reflection<> is
     type VM_Reg_Num is new Integer<0 .. 2**31-1>
       // Unique id of VM register within a given code block of an operation.
 
+    type Natural is Integer<0 .. 1_000_000>
+
     concurrent interface Environment<> is
         func Get_Current_Env() -> optional Environment
         func Outermost_Region(Env : Environment) -> optional Region
@@ -340,6 +342,15 @@ interface PSC::Reflection<> is
         is import(#tree_qualifier_is_const)
       func Qualifier_Is_Polymorphic(Tree {Kind(Tree) == #qualifier}) -> Boolean
         is import(#tree_qualifier_is_polymorphic)
+
+      func Case_Num_Alts(Tree {Kind(Tree) == #case_construct}) -> Natural
+        is import(#tree_case_num_alts)
+      func For_Loop_Num_Iters(Tree {Kind(Tree) == #for_loop}) -> Natural
+        is import(#tree_for_loop_num_iters)
+      func For_Loop_Num_Prologue(Tree {Kind(Tree) == #for_loop}) -> Natural
+        is import(#tree_for_loop_num_prologue)
+      func For_Loop_Body(T : Tree {Kind(T) == #for_loop}) -> Tree
+        is (Nth_Operand(T, [[For_Loop_Num_Iters(T) + 1]]))
     end interface Tree
 
     interface Region<> is
@@ -676,8 +687,6 @@ interface PSC::Reflection<> is
            func Hash(Val : Code_Block_Descriptor) -> Unsigned_64
              is (Hash (Val.Pc_Offset))
         end interface Code_Block_Descriptor
-
-        type Natural is Integer<0 .. 1_000_000>
 
         type Condition_Bit_Mask is Enum_Mask <Modular <2 ** 4>,
           [#compare_less => 2 ** 0,

--- a/lib/reflection.psi
+++ b/lib/reflection.psi
@@ -153,7 +153,7 @@ interface PSC::Reflection<> is
     end interface Environment
 
     interface Tree<> is
-      type Tree_Kind is Enum<
+      type Tree_Kind_Enum is Enum<
         [#annotation, #assign_stmt, #binary,
          #block_stmt, #case_construct, #conditional,
          #control_stmt, #for_loop, #identifier,
@@ -162,11 +162,11 @@ interface PSC::Reflection<> is
          #property, #qualified_name, #qualifier,
          #reference, #selection, #type_decl,
          #unary, #while_stmt]>;
-      type Unary_Op_Kind is Enum<
+      type Unary_Op_Kind_Enum is Enum<
         [#plus_op, #minus_op, #not_op, #abs_op, #is_null_op,
          #not_null_op, #meaning_op, #magnitude_op,
          #updated_value_op, #initial_value_op]>
-      type Binary_Op_Kind is Enum<
+      type Binary_Op_Kind_Enum is Enum<
         [#plus_op, #minus_op, #times_op, #divide_op,
          #mod_op, #rem_op, #power_op, #compare_op, #less_op,
          #leq_op, #equal_op, #neq_op, #geq_op, #greater_op,
@@ -176,7 +176,7 @@ interface PSC::Reflection<> is
          #closed_interval_op, #open_interval_op, #open_closed_interval_op,
          #closed_open_interval_op, #sequential_stmt_op, #parallel_stmt_op,
          #handled_stmt_op, #next_stmt_op, #then_stmt_op]>
-      type Assign_Op_Kind is Enum<
+      type Assign_Op_Kind_Enum is Enum<
         [#assign_op, #plus_assign_op, #minus_assign_op,
          #times_assign_op, #divide_assign_op, #power_assign_op,
          #combine_assign_op, #ampersand_assign_op, #and_assign_op,
@@ -212,7 +212,49 @@ interface PSC::Reflection<> is
          #proc_type_specifier, #protected_func_type,
          #protected_proc_type]>
 
-      func Kind(Tree) -> Tree_Kind
+      const Assign_Left_Op : Tree_Index := 1
+      const Assigny_Right_Op : Tree_Index := 2
+
+      const Binary_Left_Op : Tree_Index := 1
+      const Binary_Right_Op : Tree_Index := 2
+
+      const Conditional_Cond_Op : Tree_Index := 1
+      const Conditional_Then_Op : Tree_Index := 2
+      const Conditional_Else_Op : Tree_Index := 3
+
+      const Case_Selector_Op : Tree_Index := 1
+
+      const Control_Stmt_Val_Op : Tree_Index := 1
+
+      const Iterator_Obj_Op : Tree_Index := 1
+      const Iterator_While_Op : Tree_Index := 2
+
+      const Obj_Decl_Type_Op : Tree_Index := 1
+      const Obj_Decl_Value_Op : Tree_Index := 2
+
+      const Param_Decl_Type_Op : Tree_Index := 1
+      const Param_Decl_Value_Op : Tree_Index := 2
+
+      const Property_Val_Op : Tree_Index := 1
+      const Property_Id_Op : Tree_Index := 2
+
+      const Qualified_Name_Prefix_Op : Tree_Index := 1
+      const Qualified_Name_Id_Op : Tree_Index := 2
+
+      const Qualifier_Val_Op : Tree_Index := 1
+
+      const Reference_Key_Op : Tree_Index := 1
+      const Reference_Referent_Op : Tree_Index := 2
+
+      const Selection_Prefix_Op : Tree_Index := 1
+      const Selection_Selector_Op : Tree_Index := 2
+
+      const Unary_Val_Op : Tree_Index := 1
+
+      const While_Cond_Op : Tree_Index := 1
+      const While_Body_Op : Tree_Index := 2
+
+      func Kind(Tree) -> Tree_Kind_Enum
         is import(#tree_kind)
 
       func Num_Operands(Tree) -> Tree_Index
@@ -231,11 +273,11 @@ interface PSC::Reflection<> is
       func Decl_Of(Tree) -> optional Decl
         is import(#tree_decl_of)
 
-      func Unary_Op(Tree {Kind(Tree) == #unary}) -> Unary_Op_Kind
+      func Unary_Op(Tree {Kind(Tree) == #unary}) -> Unary_Op_Kind_Enum
         is import(#tree_unary_op)
-      func Binary_Op(Tree {Kind(Tree) == #binary}) -> Binary_Op_Kind
+      func Binary_Op(Tree {Kind(Tree) == #binary}) -> Binary_Op_Kind_Enum
         is import(#tree_binary_op)
-      func Assignment_Op(Tree {Kind(Tree) == #assign_stmt}) -> Assign_Op_Kind
+      func Assignment_Op(Tree {Kind(Tree) == #assign_stmt}) -> Assign_Op_Kind_Enum
         is import(#tree_assignment_op)
 
       func Conditional_Kind(Tree {Kind(Tree) == #conditional}) -> Conditional_Kind_Enum

--- a/lib/reflection.psi
+++ b/lib/reflection.psi
@@ -321,6 +321,25 @@ interface PSC::Reflection<> is
         is import(#tree_obj_decl_is_move)
       func Obj_Decl_Is_Global(Tree {Kind(Tree) == #obj_decl}) -> Boolean
         is import(#tree_obj_decl_is_global)
+
+      func Qualifier_Is_Ref(Tree {Kind(Tree) == #qualifier}) -> Boolean
+        is import(#tree_qualifier_is_ref)
+      func Qualifier_Is_Abstract(Tree {Kind(Tree) == #qualifier}) -> Boolean
+        is import(#tree_qualifier_is_abstract)
+      func Qualifier_Is_Optional(Tree {Kind(Tree) == #qualifier}) -> Boolean
+        is import(#tree_qualifier_is_optional)
+      func Qualifier_Is_Not_Null(Tree {Kind(Tree) == #qualifier}) -> Boolean
+        is import(#tree_qualifier_is_not_null)
+      func Qualifier_Is_Mutable(Tree {Kind(Tree) == #qualifier}) -> Boolean
+        is import(#tree_qualifier_is_mutable)
+      func Qualifier_Is_Concurrent(Tree {Kind(Tree) == #qualifier}) -> Boolean
+        is import(#tree_qualifier_is_concurrent)
+      func Qualifier_Is_Var(Tree {Kind(Tree) == #qualifier}) -> Boolean
+        is import(#tree_qualifier_is_var)
+      func Qualifier_Is_Const(Tree {Kind(Tree) == #qualifier}) -> Boolean
+        is import(#tree_qualifier_is_const)
+      func Qualifier_Is_Polymorphic(Tree {Kind(Tree) == #qualifier}) -> Boolean
+        is import(#tree_qualifier_is_polymorphic)
     end interface Tree
 
     interface Region<> is

--- a/lib/reflection.psi
+++ b/lib/reflection.psi
@@ -176,9 +176,41 @@ interface PSC::Reflection<> is
          #closed_interval_op, #open_interval_op, #open_closed_interval_op,
          #closed_open_interval_op, #sequential_stmt_op, #parallel_stmt_op,
          #handled_stmt_op, #next_stmt_op, #then_stmt_op]>
-      type Literal_Kind is Enum<
+      type Assign_Op_Kind is Enum<
+        [#assign_op, #plus_assign_op, #minus_assign_op,
+         #times_assign_op, #divide_assign_op, #power_assign_op,
+         #combine_assign_op, #ampersand_assign_op, #and_assign_op,
+         #or_assign_op, #xor_assign_op, #left_shift_assign_op,
+         #right_shift_assign_op, #swap_op, #move_op, #combine_move_o4p]>
+      type Literal_Kind_Enum is Enum<
         [#integer_literal, #real_literal, #string_literal,
          #char_literal, #enum_literal, #null_literal]>;
+      type Conditional_Kind_Enum is Enum<
+        [#if_stmt, #elsif_stmt, #if_expr,
+        #elsif_expr, #quest_colon]>
+      type Control_Stmt_Kind_Enum is Enum<
+        [#null_stmt, #return_stmt, #continue_stmt, #exit_stmt]>
+      type Exitable_Construct_Kind_Enum is Enum<
+        [#operation_body, #loop_stmt, #if_stmt, #case_stmt,
+         #block_stmt, #case_or_loop_stmt, #any_labeled_stmt]>
+      type For_Loop_Kind_Enum is Enum<
+        [#for_loop_statement, #existential_quantified_expr,
+         #univ_quantified_expr, #container_comprehension,
+         #map_reduce_expr]>
+      type Invocation_Kind_Enum is Enum<
+        [#operation_call, #container_indexing,
+         #class_aggregate, #container_aggregate,
+         #map_set_aggregate, #module_instantiation,
+         #is_function_of, #tuple_type_definition]>
+      type Iterator_Kind_Enum is Enum<
+        [#set_iterator, #each_value, #each_key_value,
+         #initial_next_value, #initial_value]>
+      type Operation_Kind_Enum is Enum<
+        [#function_operation, #procedure_operation,
+         #func_operation, #proc_operation, #operator_operation,
+         #op_operation, #lambda_operation, #func_type_specifier,
+         #proc_type_specifier, #protected_func_type,
+         #protected_proc_type]>
 
       func Kind(Tree) -> Tree_Kind
         is import(#tree_kind)
@@ -203,8 +235,25 @@ interface PSC::Reflection<> is
         is import(#tree_unary_op)
       func Binary_Op(Tree {Kind(Tree) == #binary}) -> Binary_Op_Kind
         is import(#tree_binary_op)
+      func Assignment_Op(Tree {Kind(Tree) == #assign_stmt}) -> Assign_Op_Kind
+        is import(#tree_assignment_op)
 
-      func Lit_Kind(Tree {Kind(Tree) == #identifier}) -> optional Literal_Kind
+      func Conditional_Kind(Tree {Kind(Tree) == #conditional}) -> Conditional_Kind_Enum
+        is import(#tree_conditional_kind)
+      func Control_Stmt_Kind(Tree {Kind(Tree) == #control_stmt}) -> Control_Stmt_Kind_Enum
+        is import(#tree_control_stmt_kind)
+      func Applies_To(Tree {Kind(Tree) == #control_stmt}) -> Exitable_Construct_Kind_Enum
+        is import(#tree_applies_to)
+      func For_Loop_Kind(Tree {Kind(Tree) == #for_loop}) -> For_Loop_Kind_Enum
+        is import(#tree_for_loop_kind)
+      func Invocation_Kind(Tree {Kind(Tree) == #invocation}) -> Invocation_Kind_Enum
+        is import(#tree_invocation_kind)
+      func Iterator_Kind(Tree {Kind(Tree) == #iterator}) -> Iterator_Kind_Enum
+        is import(#tree_iterator_kind)
+      func Operation_Kind(Tree {Kind(Tree) == #operation}) -> Operation_Kind_Enum
+        is import(#tree_operation_kind)
+
+      func Lit_Kind(Tree {Kind(Tree) == #identifier}) -> optional Literal_Kind_Enum
         is import(#tree_lit_kind)
       func Identifier(Tree {Kind(Tree) == #identifier}) -> Univ_String
         is import(#tree_identifier)

--- a/lib/reflection.psi
+++ b/lib/reflection.psi
@@ -211,6 +211,10 @@ interface PSC::Reflection<> is
          #op_operation, #lambda_operation, #func_type_specifier,
          #proc_type_specifier, #protected_func_type,
          #protected_proc_type]>
+      type Param_Decl_Kind_Enum is Enum<
+        [#default_param, #out_param, #var_param, #ref_param,
+         #ref_const_param, #ref_out_param, #ref_var_param,
+         #global_param, #global_out_param, #global_var_param]>
 
       const Assign_Left_Op : Tree_Index := 1
       const Assigny_Right_Op : Tree_Index := 2
@@ -294,6 +298,8 @@ interface PSC::Reflection<> is
         is import(#tree_iterator_kind)
       func Operation_Kind(Tree {Kind(Tree) == #operation}) -> Operation_Kind_Enum
         is import(#tree_operation_kind)
+      func Param_Decl_Kind(Tree {Kind(Tree) == #param_decl}) -> Param_Decl_Kind_Enum
+        is import(#tree_param_decl_kind)
 
       func Lit_Kind(Tree {Kind(Tree) == #identifier}) -> optional Literal_Kind_Enum
         is import(#tree_lit_kind)

--- a/lib/reflection.psi
+++ b/lib/reflection.psi
@@ -217,7 +217,7 @@ interface PSC::Reflection<> is
          #global_param, #global_out_param, #global_var_param]>
 
       const Assign_Left_Op : Tree_Index := 1
-      const Assigny_Right_Op : Tree_Index := 2
+      const Assign_Right_Op : Tree_Index := 2
 
       const Binary_Left_Op : Tree_Index := 1
       const Binary_Right_Op : Tree_Index := 2

--- a/lib/reflection.psi
+++ b/lib/reflection.psi
@@ -299,6 +299,22 @@ interface PSC::Reflection<> is
         is import(#tree_lit_kind)
       func Identifier(Tree {Kind(Tree) == #identifier}) -> Univ_String
         is import(#tree_identifier)
+
+      func Case_Is_Expr(Tree {Kind(Tree) == #case_construct}) -> Boolean
+        is import(#tree_case_is_expr)
+
+      func Obj_Decl_Is_Var(Tree {Kind(Tree) == #obj_decl}) -> Boolean
+        is import(#tree_obj_decl_is_var)
+      func Obj_Decl_Is_Const(Tree {Kind(Tree) == #obj_decl}) -> Boolean
+        is import(#tree_obj_decl_is_const)
+      func Obj_Decl_Is_Ref(Tree {Kind(Tree) == #obj_decl}) -> Boolean
+        is import(#tree_obj_decl_is_ref)
+      func Obj_Decl_Is_Optional(Tree {Kind(Tree) == #obj_decl}) -> Boolean
+        is import(#tree_obj_decl_is_optional)
+      func Obj_Decl_Is_Move(Tree {Kind(Tree) == #obj_decl}) -> Boolean
+        is import(#tree_obj_decl_is_move)
+      func Obj_Decl_Is_Global(Tree {Kind(Tree) == #obj_decl}) -> Boolean
+        is import(#tree_obj_decl_is_global)
     end interface Tree
 
     interface Region<> is

--- a/semantics/psc-trees-semantics-translator.adb
+++ b/semantics/psc-trees-semantics-translator.adb
@@ -36,14 +36,16 @@ with PSC.Univ_Strings;
 
 with PSC.Trees.Assign_Stmt;
 with PSC.Trees.Binary;
+with PSC.Trees.Case_Construct;
 with PSC.Trees.Conditional;
 with PSC.Trees.Control_Stmt;
 with PSC.Trees.For_Loop_Construct;
+with PSC.Trees.Obj_Decl;
 with PSC.Trees.Operation;
-with PSC.Trees.Unary;
 with PSC.Trees.Identifier;
 with PSC.Trees.Invocation;
 with PSC.Trees.Iterator;
+with PSC.Trees.Unary;
 
 with Ada.Text_IO; use Ada.Text_IO;
 
@@ -449,6 +451,48 @@ package body PSC.Trees.Semantics.Translator is
       Params : Word_Ptr;
       Static_Link : Non_Op_Map_Type_Ptr);
    pragma Export (Ada, Tree_Operation_Kind, "_psc_tree_operation_kind");
+
+   procedure Tree_Case_Is_Expr
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Case_Is_Expr, "_psc_tree_case_is_expr");
+
+   procedure Tree_Obj_Decl_Is_Var
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Obj_Decl_Is_Var, "_psc_tree_obj_decl_is_var");
+
+   procedure Tree_Obj_Decl_Is_Const
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Obj_Decl_Is_Const, "_psc_tree_obj_decl_is_const");
+
+   procedure Tree_Obj_Decl_Is_Ref
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Obj_Decl_Is_Ref, "_psc_tree_obj_decl_is_ref");
+
+   procedure Tree_Obj_Decl_Is_Optional
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Obj_Decl_Is_Optional, "_psc_tree_obj_decl_is_optional");
+
+   procedure Tree_Obj_Decl_Is_Move
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Obj_Decl_Is_Move, "_psc_tree_obj_decl_is_move");
+
+   procedure Tree_Obj_Decl_Is_Global
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Obj_Decl_Is_Global, "_psc_tree_obj_decl_is_global");
 
    procedure Tree_Source_Pos
      (Context : in out Exec_Context;
@@ -2728,15 +2772,11 @@ package body PSC.Trees.Semantics.Translator is
          (Params, 0, Null_Value);
    end Tree_Assignment_Op;
 
-   ---------------------------
-   -- Tree_Conditional_Kind --
-   ---------------------------
-
    procedure Tree_Conditional_Kind
       (Context : in out Exec_Context;
        Params : Word_Ptr;
        Static_Link : Non_Op_Map_Type_Ptr) is
-      --  func Get_Conditional_Kind(Tree {Kind(Tree) == #conditional})
+      --  func Conditional_Kind(Tree {Kind(Tree) == #conditional})
       --    -> Conditional_Kind import(#tree_conditional_kind)
       Op : constant Optional_Tree :=
          To_Optional_Tree (Fetch_Word (Params, 1));
@@ -3007,6 +3047,195 @@ package body PSC.Trees.Semantics.Translator is
       Store_Word
          (Params, 0, Null_Value);
    end Tree_Identifier;
+
+   procedure Tree_Case_Is_Expr
+      (Context : in out Exec_Context;
+       Params : Word_Ptr;
+       Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Case_Is_Expr(Tree {Kind(Tree) == #case_construct}) -> Boolean
+      --    is import(#tree_case_is_expr)
+      Case_Is_Expr : Boolean := False;
+      Target : constant Word_Type := Fetch_Word (Params, 0);
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Case_Construct.Tree then
+               Case_Is_Expr := Trees.Case_Construct.Tree
+                  (Op_Tree).Is_Case_Expr;
+            end if;
+         end;
+      end if;
+
+      Store_Word
+        (Params, 0,
+         Boolean'Pos (Case_Is_Expr));
+   end Tree_Case_Is_Expr;
+
+   procedure Tree_Obj_Decl_Is_Var
+      (Context : in out Exec_Context;
+       Params : Word_Ptr;
+       Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Obj_Decl_Is_Var(Tree {Kind(Tree) == #obj_decl}) -> Boolean
+      --    is import(#tree_obj_decl_is_var)
+      Is_Var : Boolean := False;
+      Target : constant Word_Type := Fetch_Word (Params, 0);
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Obj_Decl.Tree then
+               Is_Var := Trees.Obj_Decl.Tree
+                  (Op_Tree).Is_Var;
+            end if;
+         end;
+      end if;
+
+      Store_Word
+        (Params, 0,
+         Boolean'Pos (Is_Var));
+   end Tree_Obj_Decl_Is_Var;
+
+   procedure Tree_Obj_Decl_Is_Const
+      (Context : in out Exec_Context;
+       Params : Word_Ptr;
+       Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Obj_Decl_Is_Const(Tree {Kind(Tree) == #obj_decl}) -> Boolean
+      --    is import(#tree_obj_decl_is_const)
+      Is_Const : Boolean := False;
+      Target : constant Word_Type := Fetch_Word (Params, 0);
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Obj_Decl.Tree then
+               Is_Const := Trees.Obj_Decl.Tree
+                  (Op_Tree).Is_Const;
+            end if;
+         end;
+      end if;
+
+      Store_Word
+        (Params, 0,
+         Boolean'Pos (Is_Const));
+   end Tree_Obj_Decl_Is_Const;
+
+   procedure Tree_Obj_Decl_Is_Ref
+      (Context : in out Exec_Context;
+       Params : Word_Ptr;
+       Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Obj_Decl_Is_Ref(Tree {Kind(Tree) == #obj_decl}) -> Boolean
+      --    is import(#tree_obj_decl_is_ref)
+      Is_Ref : Boolean := False;
+      Target : constant Word_Type := Fetch_Word (Params, 0);
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Obj_Decl.Tree then
+               Is_Ref := Trees.Obj_Decl.Tree
+                  (Op_Tree).Is_Ref;
+            end if;
+         end;
+      end if;
+
+      Store_Word
+        (Params, 0,
+         Boolean'Pos (Is_Ref));
+   end Tree_Obj_Decl_Is_Ref;
+
+   procedure Tree_Obj_Decl_Is_Optional
+      (Context : in out Exec_Context;
+       Params : Word_Ptr;
+       Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Obj_Decl_Is_Optional(Tree {Kind(Tree) == #obj_decl}) -> Boolean
+      --    is import(#tree_obj_decl_is_optional)
+      Is_Optional : Boolean := False;
+      Target : constant Word_Type := Fetch_Word (Params, 0);
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Obj_Decl.Tree then
+               Is_Optional := Trees.Obj_Decl.Tree
+                  (Op_Tree).Is_Optional;
+            end if;
+         end;
+      end if;
+
+      Store_Word
+        (Params, 0,
+         Boolean'Pos (Is_Optional));
+   end Tree_Obj_Decl_Is_Optional;
+
+   procedure Tree_Obj_Decl_Is_Move
+      (Context : in out Exec_Context;
+       Params : Word_Ptr;
+       Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Obj_Decl_Is_Move(Tree {Kind(Tree) == #obj_decl}) -> Boolean
+      --    is import(#tree_obj_decl_is_move)
+      Is_Move : Boolean := False;
+      Target : constant Word_Type := Fetch_Word (Params, 0);
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Obj_Decl.Tree then
+               Is_Move := Trees.Obj_Decl.Tree
+                  (Op_Tree).Is_Move;
+            end if;
+         end;
+      end if;
+
+      Store_Word
+        (Params, 0,
+         Boolean'Pos (Is_Move));
+   end Tree_Obj_Decl_Is_Move;
+
+   procedure Tree_Obj_Decl_Is_Global
+      (Context : in out Exec_Context;
+       Params : Word_Ptr;
+       Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Obj_Decl_Is_Global(Tree {Kind(Tree) == #obj_decl}) -> Boolean
+      --    is import(#tree_obj_decl_is_global)
+      Is_Global : Boolean := False;
+      Target : constant Word_Type := Fetch_Word (Params, 0);
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Obj_Decl.Tree then
+               Is_Global := Trees.Obj_Decl.Tree
+                  (Op_Tree).Is_Global;
+            end if;
+         end;
+      end if;
+
+      Store_Word
+        (Params, 0,
+         Boolean'Pos (Is_Global));
+   end Tree_Obj_Decl_Is_Global;
 
    procedure Decl_Region
      (Context : in out Exec_Context;
@@ -6571,6 +6800,34 @@ begin  --  PSC.Trees.Semantics.Translator;
    Interpreter.Builtins.Register_Builtin
      (Strings.String_Lookup ("#tree_identifier"),
       Tree_Identifier'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_case_is_expr"),
+      Tree_Case_Is_Expr'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_obj_decl_is_var"),
+      Tree_Obj_Decl_Is_Var'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_obj_decl_is_const"),
+      Tree_Obj_Decl_Is_Const'Access);
+      
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_obj_decl_is_ref"),
+      Tree_Obj_Decl_Is_Ref'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_obj_decl_is_optional"),
+      Tree_Obj_Decl_Is_Optional'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_obj_decl_is_move"),
+      Tree_Obj_Decl_Is_Move'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_obj_decl_is_global"),
+      Tree_Obj_Decl_Is_Global'Access);
 
    Interpreter.Builtins.Register_Builtin
      (Strings.String_Lookup ("#tree_source_pos"),

--- a/semantics/psc-trees-semantics-translator.adb
+++ b/semantics/psc-trees-semantics-translator.adb
@@ -2514,9 +2514,9 @@ package body PSC.Trees.Semantics.Translator is
    end Region_Sibling_Region;
 
    procedure Region_Num_Trees
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Num_Trees(Region) -> Tree_Index
       --    is import(#region_num_trees)
       Region : constant Symbols.Region_Ptr :=
@@ -2524,14 +2524,14 @@ package body PSC.Trees.Semantics.Translator is
       Statements : constant Trees.Lists.List := Region.Stmt_List;
    begin
       Store_Word
-         (Params, 0,
+        (Params, 0,
          Word_Type (Trees.Lists.Length (Statements)));
    end Region_Num_Trees;
 
    procedure Region_Nth_Tree
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Nth_Tree(Region; Tree_Index) -> optional Tree
       --    is import(#region_nth_tree)
       Region : constant Symbols.Region_Ptr :=
@@ -2541,20 +2541,20 @@ package body PSC.Trees.Semantics.Translator is
    begin
       if Index > 0 and then Index <= Trees.Lists.Length (Statements) then
          Store_Word (Params, 0, To_Word_Type
-            (Trees.Lists.Nth_Element (Statements, Index)));
+           (Trees.Lists.Nth_Element (Statements, Index)));
       else
          Store_Word (Params, 0, Null_Value);
       end if;
    end Region_Nth_Tree;
 
    procedure Tree_Kind
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Kind(Tree) -> Tree_Kind
       --    is import(#tree_kind)
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       --  Determine kind of tree
       if Not_Null(Op) then
@@ -2571,13 +2571,13 @@ package body PSC.Trees.Semantics.Translator is
    end Tree_Kind;
 
    procedure Tree_Num_Operands
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Num_Operands(Tree) -> Tree_Index
       --    is import(#tree_num_operands)
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Op = Null_Optional_Tree then
          Store_Word (Params, 0, 0);
@@ -2586,20 +2586,20 @@ package body PSC.Trees.Semantics.Translator is
             Op_Tree : constant Tree'Class := Tree_Of (Op);
          begin
             Store_Word
-               (Params, 0,
-                Word_Type (Num_Operands (Op_Tree)));
+              (Params, 0,
+               Word_Type (Num_Operands (Op_Tree)));
          end;
       end if;
    end Tree_Num_Operands;
 
    procedure Tree_Nth_Operand
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Nth_Operand(Tree; Tree_Index) -> optional Tree
       --    is import(#tree_nth_operand)
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
       Index : constant Word_Type := Fetch_Word (Params, 2);
    begin
       if Not_Null (Op) and then Index > 0 then
@@ -2608,21 +2608,21 @@ package body PSC.Trees.Semantics.Translator is
          begin
             if Natural(Index) <= Num_Operands(Op_Tree) then
                Store_Word
-                  (Params, 0, To_Word_Type 
-                   (Nth_Operand (Op_Tree, Positive(Index))));
+                 (Params, 0, To_Word_Type 
+                  (Nth_Operand (Op_Tree, Positive(Index))));
                return;
             end if;
          end;
       end if;
 
       Store_Word
-         (Params, 0, Null_Value);
+        (Params, 0, Null_Value);
    end Tree_Nth_Operand;
 
    procedure Tree_Pre_Annotation
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Pre_Annotation(Tree) -> optional Tree
       --    is import(#tree_pre_annotation)
       Op : constant Optional_Tree :=
@@ -2641,13 +2641,13 @@ package body PSC.Trees.Semantics.Translator is
    end Tree_Pre_Annotation;
 
    procedure Tree_Post_Annotation
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Post_Annotation(Tree) -> optional Tree
       --    is import(#tree_post_annotation)
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -2662,16 +2662,16 @@ package body PSC.Trees.Semantics.Translator is
    end Tree_Post_Annotation;
 
    procedure Tree_Source_Pos
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Source_Pos(Tree) -> optional Source_Position
       --    is import(#tree_source_pos)
       use Source_Positions;
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
       Pos : constant Source_Positions.Source_Position :=
-         Source_Pos (Op);
+        Source_Pos (Op);
    begin
       if Pos = Source_Positions.Null_Source_Position then
          Store_Word
@@ -2684,27 +2684,27 @@ package body PSC.Trees.Semantics.Translator is
    end Tree_Source_Pos;
 
    procedure Tree_Resolved_Type
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Resolved_Type(Tree) -> optional Type_Descriptor
       --    is import(#tree_resolved_type)
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
       Op_Sem : constant Root_Sem_Ptr := Sem_Info (Op);
    begin
       if Op_Sem /= null and then 
-         Op_Sem.all in Operand_Semantic_Info'Class
+        Op_Sem.all in Operand_Semantic_Info'Class
       then
          declare
             Opnd_Sem : constant Operand_Sem_Ptr :=
-               Operand_Sem_Ptr (Op_Sem);
+              Operand_Sem_Ptr (Op_Sem);
             Res_Type : constant Type_Sem_Ptr :=
-               Opnd_Sem.Resolved_Type;
+              Opnd_Sem.Resolved_Type;
          begin
             if Res_Type /= null then
                Store_Word
-               (Params, 0,
+                 (Params, 0,
                   To_Word_Type (Get_Type_Desc
                   (Context, Res_Type.Type_Descriptor_Location)));
                return;
@@ -2717,20 +2717,20 @@ package body PSC.Trees.Semantics.Translator is
    end Tree_Resolved_Type;
 
    procedure Tree_Decl_Of
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Decl_Of(Tree) -> optional Decl
       --    is import(#tree_decl_of)
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
       Op_Sem : constant Root_Sem_Ptr := Sem_Info (Op);
    begin
       if Op_Sem /= null and then 
-         (Op_Sem.all in Module_Semantic_Info'Class or else
-          Op_Sem.all in Type_Semantic_Info'Class or else
-          Op_Sem.all in Object_Semantic_Info'Class or else
-          Op_Sem.all in Operation_Semantic_Info'Class)
+        (Op_Sem.all in Module_Semantic_Info'Class or else
+         Op_Sem.all in Type_Semantic_Info'Class or else
+         Op_Sem.all in Object_Semantic_Info'Class or else
+         Op_Sem.all in Operation_Semantic_Info'Class)
       then
          Store_Word
            (Params, 0, To_Word_Type (Op_Sem));
@@ -2741,13 +2741,13 @@ package body PSC.Trees.Semantics.Translator is
    end Tree_Decl_Of;
 
    procedure Tree_Unary_Op
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Unary_Op(Tree {Kind(Tree) == #unary}) -> Unary_Op_Kind
       --    is import(#tree_unary_op)
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -2756,11 +2756,11 @@ package body PSC.Trees.Semantics.Translator is
             if Op_Tree in Trees.Unary.Tree then
                declare
                   Un_Tree : constant Trees.Unary.Tree :=
-                     Trees.Unary.Tree (Op_Tree);
+                    Trees.Unary.Tree (Op_Tree);
                begin
                   Store_Word
-                     (Params, 0,
-                      Trees.Unary.Unary_Operator_Enum'Pos (Un_Tree.Operator));
+                    (Params, 0,
+                     Trees.Unary.Unary_Operator_Enum'Pos (Un_Tree.Operator));
                   return;
                end;
             end if;
@@ -2768,17 +2768,17 @@ package body PSC.Trees.Semantics.Translator is
       end if;
 
       Store_Word
-         (Params, 0, Null_Value);
+        (Params, 0, Null_Value);
    end Tree_Unary_Op;
 
    procedure Tree_Binary_Op
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Binary_Op(Tree {Kind(Tree) == #binary}) -> Binary_Op_Kind
       --    is import(#tree_binary_op)
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -2787,12 +2787,11 @@ package body PSC.Trees.Semantics.Translator is
             if Op_Tree in Trees.Binary.Tree'Class then
                declare
                   Bin_Tree : constant Trees.Binary.Tree :=
-                     Trees.Binary.Tree (Op_Tree);
+                    Trees.Binary.Tree (Op_Tree);
                   Index : Word_Type := Trees.Binary.Binary_Operator_Enum'Pos
-                     (Bin_Tree.Operator);
+                    (Bin_Tree.Operator);
                begin
-                  Store_Word
-                     (Params, 0, Index - 1);
+                  Store_Word (Params, 0, Index - 1);
                   return;
                end;
             end if;
@@ -2800,17 +2799,17 @@ package body PSC.Trees.Semantics.Translator is
       end if;
 
       Store_Word
-         (Params, 0, Null_Value);
+        (Params, 0, Null_Value);
    end Tree_Binary_Op;
 
    procedure Tree_Assignment_Op
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Assignment_Op(Tree {Kind(Tree) == #assign_stmt}) -> Assign_Op_Kind
       --    is import(#tree_assignment_op)
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -2819,9 +2818,9 @@ package body PSC.Trees.Semantics.Translator is
             if Op_Tree in Trees.Assign_Stmt.Tree'Class then
                declare
                   Assign_Tree : constant Trees.Assign_Stmt.Tree :=
-                     Trees.Assign_Stmt.Tree (Op_Tree);
+                    Trees.Assign_Stmt.Tree (Op_Tree);
                   Index : Word_Type := Trees.Assign_Stmt.Assign_Operator_Enum'Pos
-                     (Assign_Tree.Assign_Operator);
+                    (Assign_Tree.Assign_Operator);
                begin
                   Store_Word (Params, 0, Index);
                   return;
@@ -2831,17 +2830,17 @@ package body PSC.Trees.Semantics.Translator is
       end if;
 
       Store_Word
-         (Params, 0, Null_Value);
+        (Params, 0, Null_Value);
    end Tree_Assignment_Op;
 
    procedure Tree_Conditional_Kind
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Conditional_Kind(Tree {Kind(Tree) == #conditional})
       --    -> Conditional_Kind import(#tree_conditional_kind)
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -2850,9 +2849,9 @@ package body PSC.Trees.Semantics.Translator is
             if Op_Tree in Trees.Conditional.Tree'Class then
                declare
                   Cond_Tree : constant Trees.Conditional.Tree :=
-                     Trees.Conditional.Tree (Op_Tree);
+                    Trees.Conditional.Tree (Op_Tree);
                   Index : Word_Type := Trees.Conditional.Conditional_Kind_Enum'Pos
-                     (Cond_Tree.Kind);
+                    (Cond_Tree.Kind);
                begin
                   Store_Word (Params, 0, Index);
                   return;
@@ -2862,17 +2861,17 @@ package body PSC.Trees.Semantics.Translator is
       end if;
 
       Store_Word
-         (Params, 0, Null_Value);
+        (Params, 0, Null_Value);
    end Tree_Conditional_Kind;
 
    procedure Tree_Control_Stmt_Kind
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Get_Control_Stmt_Kind(Tree {Kind(Tree) == #control_stmt}) -> Control_Stmt_Kind
       --    is import(#tree_control_stmt_kind)
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -2881,9 +2880,9 @@ package body PSC.Trees.Semantics.Translator is
             if Op_Tree in Trees.Control_Stmt.Tree'Class then
                declare
                   Ctrl_Tree : constant Trees.Control_Stmt.Tree :=
-                     Trees.Control_Stmt.Tree (Op_Tree);
+                    Trees.Control_Stmt.Tree (Op_Tree);
                   Index : Word_Type := Trees.Control_Stmt.Control_Stmt_Enum'Pos
-                     (Ctrl_Tree.Kind);
+                    (Ctrl_Tree.Kind);
                begin
                   Store_Word (Params, 0, Index);
                   return;
@@ -2893,17 +2892,17 @@ package body PSC.Trees.Semantics.Translator is
       end if;
 
       Store_Word
-         (Params, 0, Null_Value);
+        (Params, 0, Null_Value);
    end Tree_Control_Stmt_Kind;
 
    procedure Tree_Applies_To
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Applies_To(Tree {Kind(Tree) == #control_stmt}) -> Exitable_Construct_Kind
       --    is import(#tree_applies_to)
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -2912,9 +2911,9 @@ package body PSC.Trees.Semantics.Translator is
             if Op_Tree in Trees.Control_Stmt.Tree'Class then
                declare
                   AT_Tree : constant Trees.Control_Stmt.Tree :=
-                     Trees.Control_Stmt.Tree (Op_Tree);
+                    Trees.Control_Stmt.Tree (Op_Tree);
                   Index : Word_Type := Trees.Control_Stmt.Exitable_Construct_Enum'Pos
-                     (AT_Tree.Applies_To);
+                    (AT_Tree.Applies_To);
                begin
                   Store_Word (Params, 0, Index);
                   return;
@@ -2924,17 +2923,17 @@ package body PSC.Trees.Semantics.Translator is
       end if;
 
       Store_Word
-         (Params, 0, Null_Value);
+        (Params, 0, Null_Value);
    end Tree_Applies_To;
 
    procedure Tree_For_Loop_Kind
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func For_Loop_Kind(Tree {Kind(Tree) == #for_loop}) -> For_Loop_Kind_Enum
       --    is import(#tree_for_loop_kind)
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -2943,9 +2942,9 @@ package body PSC.Trees.Semantics.Translator is
             if Op_Tree in Trees.For_Loop_Construct.Tree'Class then
                declare
                   Loop_Tree : constant Trees.For_Loop_Construct.Tree :=
-                     Trees.For_Loop_Construct.Tree (Op_Tree);
+                    Trees.For_Loop_Construct.Tree (Op_Tree);
                   Index : Word_Type := Trees.For_Loop_Construct.For_Loop_Kind_Enum'Pos
-                     (Loop_Tree.Kind);
+                    (Loop_Tree.Kind);
                begin
                   Store_Word (Params, 0, Index);
                   return;
@@ -2955,17 +2954,17 @@ package body PSC.Trees.Semantics.Translator is
       end if;
 
       Store_Word
-         (Params, 0, Null_Value);
+        (Params, 0, Null_Value);
    end Tree_For_Loop_Kind;
 
    procedure Tree_Invocation_Kind
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Invocation_Kind(Tree {Kind(Tree) == #invocation}) -> Invocation_Kind_Enum
       --    is import(#tree_invocation_kind)
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -2974,9 +2973,9 @@ package body PSC.Trees.Semantics.Translator is
             if Op_Tree in Trees.Invocation.Tree'Class then
                declare
                   Invoc_Tree : constant Trees.Invocation.Tree :=
-                     Trees.Invocation.Tree (Op_Tree);
+                    Trees.Invocation.Tree (Op_Tree);
                   Index : Word_Type := Trees.Invocation.Invocation_Kind_Enum'Pos
-                     (Invoc_Tree.Kind);
+                    (Invoc_Tree.Kind);
                begin
                   Store_Word (Params, 0, Index);
                   return;
@@ -2986,17 +2985,17 @@ package body PSC.Trees.Semantics.Translator is
       end if;
 
       Store_Word
-         (Params, 0, Null_Value);
+        (Params, 0, Null_Value);
    end Tree_Invocation_Kind;
 
    procedure Tree_Iterator_Kind
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Iterator_Kind(Tree {Kind(Tree) == #iterator}) -> Iterator_Kind_Enum
       --    is import(#tree_iterator_kind)
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -3005,9 +3004,9 @@ package body PSC.Trees.Semantics.Translator is
             if Op_Tree in Trees.Iterator.Tree'Class then
                declare
                   Iter_Tree : constant Trees.Iterator.Tree :=
-                     Trees.Iterator.Tree (Op_Tree);
+                    Trees.Iterator.Tree (Op_Tree);
                   Index : Word_Type := Trees.Iterator.Iterator_Kind_Enum'Pos
-                     (Iter_Tree.Kind);
+                    (Iter_Tree.Kind);
                begin
                   Store_Word (Params, 0, Index);
                   return;
@@ -3017,17 +3016,17 @@ package body PSC.Trees.Semantics.Translator is
       end if;
 
       Store_Word
-         (Params, 0, Null_Value);
+        (Params, 0, Null_Value);
    end Tree_Iterator_Kind;
 
    procedure Tree_Operation_Kind
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Operation_Kind(Tree {Kind(Tree) == #operation}) -> Operation_Kind_Enum
       --    is import(#tree_operation_kind)
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -3036,9 +3035,9 @@ package body PSC.Trees.Semantics.Translator is
             if Op_Tree in Trees.Operation.Tree'Class then
                declare
                   Operand_Tree : constant Trees.Operation.Tree :=
-                     Trees.Operation.Tree (Op_Tree);
+                    Trees.Operation.Tree (Op_Tree);
                   Index : Word_Type := Trees.Operation.Operation_Kind_Enum'Pos
-                     (Operand_Tree.Operation_Kind);
+                    (Operand_Tree.Operation_Kind);
                begin
                   Store_Word (Params, 0, Index);
                   return;
@@ -3048,17 +3047,17 @@ package body PSC.Trees.Semantics.Translator is
       end if;
 
       Store_Word
-         (Params, 0, Null_Value);
+        (Params, 0, Null_Value);
    end Tree_Operation_Kind;
 
    procedure Tree_Param_Decl_Kind
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Param_Decl_Kind(Tree {Kind(Tree) == #param_decl}) -> Param_Decl_Kind_Enum
       --    is import(#tree_param_decl_kind)
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -3067,9 +3066,9 @@ package body PSC.Trees.Semantics.Translator is
             if Op_Tree in Trees.Param_Decl.Tree'Class then
                declare
                   Param_Tree : constant Trees.Param_Decl.Tree :=
-                     Trees.Param_Decl.Tree (Op_Tree);
+                    Trees.Param_Decl.Tree (Op_Tree);
                   Index : Word_Type := Trees.Param_Decl.Param_Kind'Pos
-                     (Param_Tree.Kind);
+                    (Param_Tree.Kind);
                begin
                   Store_Word (Params, 0, Index);
                   return;
@@ -3079,17 +3078,17 @@ package body PSC.Trees.Semantics.Translator is
       end if;
 
       Store_Word
-         (Params, 0, Null_Value);
+        (Params, 0, Null_Value);
    end Tree_Param_Decl_Kind;
 
    procedure Tree_Lit_Kind
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Lit_Kind(Tree {Kind(Tree) == #identifier}) -> optional Literal_Kind
       --    is import(#tree_lit_kind)
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
       Op_Sem : constant Root_Sem_Ptr := Sem_Info (Op);
    begin
       if Op_Sem /= null and then Op_Sem.all in Literal_Semantic_Info'Class then
@@ -3106,18 +3105,18 @@ package body PSC.Trees.Semantics.Translator is
       end if;
 
       Store_Word
-         (Params, 0, Null_Value);
+        (Params, 0, Null_Value);
    end Tree_Lit_Kind;
 
    procedure Tree_Identifier
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Identifier(Tree {Kind(Tree) == #identifier}) -> Univ_String
       --    is import(#tree_identifier)
       Target : constant Word_Type := Fetch_Word (Params, 0);
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -3126,9 +3125,9 @@ package body PSC.Trees.Semantics.Translator is
             if Op_Tree in Trees.Identifier.Tree then
                declare
                   Ident_Tree : Trees.Identifier.Tree :=
-                     Trees.Identifier.Tree (Op_Tree);
+                    Trees.Identifier.Tree (Op_Tree);
                   Word_Str : Word_Type := To_Univ_String_Word
-                     (Ident_Tree.Str, Target);
+                    (Ident_Tree.Str, Target);
                begin
                   Store_Word (Params, 0, Word_Str);
                   return;
@@ -3138,19 +3137,19 @@ package body PSC.Trees.Semantics.Translator is
       end if;
 
       Store_Word
-         (Params, 0, Null_Value);
+        (Params, 0, Null_Value);
    end Tree_Identifier;
 
    procedure Tree_Case_Is_Expr
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Case_Is_Expr(Tree {Kind(Tree) == #case_construct}) -> Boolean
       --    is import(#tree_case_is_expr)
       Case_Is_Expr : Boolean := False;
       Target : constant Word_Type := Fetch_Word (Params, 0);
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -3158,7 +3157,7 @@ package body PSC.Trees.Semantics.Translator is
          begin
             if Op_Tree in Trees.Case_Construct.Tree then
                Case_Is_Expr := Trees.Case_Construct.Tree
-                  (Op_Tree).Is_Case_Expr;
+                 (Op_Tree).Is_Case_Expr;
             end if;
          end;
       end if;
@@ -3169,15 +3168,15 @@ package body PSC.Trees.Semantics.Translator is
    end Tree_Case_Is_Expr;
 
    procedure Tree_Obj_Decl_Is_Var
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Obj_Decl_Is_Var(Tree {Kind(Tree) == #obj_decl}) -> Boolean
       --    is import(#tree_obj_decl_is_var)
       Is_Var : Boolean := False;
       Target : constant Word_Type := Fetch_Word (Params, 0);
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -3185,7 +3184,7 @@ package body PSC.Trees.Semantics.Translator is
          begin
             if Op_Tree in Trees.Obj_Decl.Tree then
                Is_Var := Trees.Obj_Decl.Tree
-                  (Op_Tree).Is_Var;
+                 (Op_Tree).Is_Var;
             end if;
          end;
       end if;
@@ -3196,15 +3195,15 @@ package body PSC.Trees.Semantics.Translator is
    end Tree_Obj_Decl_Is_Var;
 
    procedure Tree_Obj_Decl_Is_Const
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Obj_Decl_Is_Const(Tree {Kind(Tree) == #obj_decl}) -> Boolean
       --    is import(#tree_obj_decl_is_const)
       Is_Const : Boolean := False;
       Target : constant Word_Type := Fetch_Word (Params, 0);
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -3212,7 +3211,7 @@ package body PSC.Trees.Semantics.Translator is
          begin
             if Op_Tree in Trees.Obj_Decl.Tree then
                Is_Const := Trees.Obj_Decl.Tree
-                  (Op_Tree).Is_Const;
+                 (Op_Tree).Is_Const;
             end if;
          end;
       end if;
@@ -3223,15 +3222,15 @@ package body PSC.Trees.Semantics.Translator is
    end Tree_Obj_Decl_Is_Const;
 
    procedure Tree_Obj_Decl_Is_Ref
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Obj_Decl_Is_Ref(Tree {Kind(Tree) == #obj_decl}) -> Boolean
       --    is import(#tree_obj_decl_is_ref)
       Is_Ref : Boolean := False;
       Target : constant Word_Type := Fetch_Word (Params, 0);
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -3239,7 +3238,7 @@ package body PSC.Trees.Semantics.Translator is
          begin
             if Op_Tree in Trees.Obj_Decl.Tree then
                Is_Ref := Trees.Obj_Decl.Tree
-                  (Op_Tree).Is_Ref;
+                 (Op_Tree).Is_Ref;
             end if;
          end;
       end if;
@@ -3250,15 +3249,15 @@ package body PSC.Trees.Semantics.Translator is
    end Tree_Obj_Decl_Is_Ref;
 
    procedure Tree_Obj_Decl_Is_Optional
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Obj_Decl_Is_Optional(Tree {Kind(Tree) == #obj_decl}) -> Boolean
       --    is import(#tree_obj_decl_is_optional)
       Is_Optional : Boolean := False;
       Target : constant Word_Type := Fetch_Word (Params, 0);
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -3266,7 +3265,7 @@ package body PSC.Trees.Semantics.Translator is
          begin
             if Op_Tree in Trees.Obj_Decl.Tree then
                Is_Optional := Trees.Obj_Decl.Tree
-                  (Op_Tree).Is_Optional;
+                 (Op_Tree).Is_Optional;
             end if;
          end;
       end if;
@@ -3277,15 +3276,15 @@ package body PSC.Trees.Semantics.Translator is
    end Tree_Obj_Decl_Is_Optional;
 
    procedure Tree_Obj_Decl_Is_Move
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Obj_Decl_Is_Move(Tree {Kind(Tree) == #obj_decl}) -> Boolean
       --    is import(#tree_obj_decl_is_move)
       Is_Move : Boolean := False;
       Target : constant Word_Type := Fetch_Word (Params, 0);
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -3293,7 +3292,7 @@ package body PSC.Trees.Semantics.Translator is
          begin
             if Op_Tree in Trees.Obj_Decl.Tree then
                Is_Move := Trees.Obj_Decl.Tree
-                  (Op_Tree).Is_Move;
+                 (Op_Tree).Is_Move;
             end if;
          end;
       end if;
@@ -3304,15 +3303,15 @@ package body PSC.Trees.Semantics.Translator is
    end Tree_Obj_Decl_Is_Move;
 
    procedure Tree_Obj_Decl_Is_Global
-      (Context : in out Exec_Context;
-       Params : Word_Ptr;
-       Static_Link : Non_Op_Map_Type_Ptr) is
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
       --  func Obj_Decl_Is_Global(Tree {Kind(Tree) == #obj_decl}) -> Boolean
       --    is import(#tree_obj_decl_is_global)
       Is_Global : Boolean := False;
       Target : constant Word_Type := Fetch_Word (Params, 0);
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -3320,7 +3319,7 @@ package body PSC.Trees.Semantics.Translator is
          begin
             if Op_Tree in Trees.Obj_Decl.Tree then
                Is_Global := Trees.Obj_Decl.Tree
-                  (Op_Tree).Is_Global;
+                 (Op_Tree).Is_Global;
             end if;
          end;
       end if;
@@ -3339,7 +3338,7 @@ package body PSC.Trees.Semantics.Translator is
       Is_Ref : Boolean := False;
       Target : constant Word_Type := Fetch_Word (Params, 0);
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -3347,7 +3346,7 @@ package body PSC.Trees.Semantics.Translator is
          begin
             if Op_Tree in Trees.Qualifier.Tree then
                Is_Ref := Trees.Qualifier.Tree
-                  (Op_Tree).Qualifiers (Trees.Qualifier.Is_Ref);
+                 (Op_Tree).Qualifiers (Trees.Qualifier.Is_Ref);
             end if;
          end;
       end if;
@@ -3366,7 +3365,7 @@ package body PSC.Trees.Semantics.Translator is
       Is_Abstract : Boolean := False;
       Target : constant Word_Type := Fetch_Word (Params, 0);
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -3374,7 +3373,7 @@ package body PSC.Trees.Semantics.Translator is
          begin
             if Op_Tree in Trees.Qualifier.Tree then
                Is_Abstract := Trees.Qualifier.Tree
-                  (Op_Tree).Qualifiers (Trees.Qualifier.Is_Abstract);
+                 (Op_Tree).Qualifiers (Trees.Qualifier.Is_Abstract);
             end if;
          end;
       end if;
@@ -3393,7 +3392,7 @@ package body PSC.Trees.Semantics.Translator is
       Is_Optional : Boolean := False;
       Target : constant Word_Type := Fetch_Word (Params, 0);
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -3401,7 +3400,7 @@ package body PSC.Trees.Semantics.Translator is
          begin
             if Op_Tree in Trees.Qualifier.Tree then
                Is_Optional := Trees.Qualifier.Tree
-                  (Op_Tree).Qualifiers (Trees.Qualifier.Is_Optional);
+                 (Op_Tree).Qualifiers (Trees.Qualifier.Is_Optional);
             end if;
          end;
       end if;
@@ -3420,7 +3419,7 @@ package body PSC.Trees.Semantics.Translator is
       Is_Not_Null : Boolean := False;
       Target : constant Word_Type := Fetch_Word (Params, 0);
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -3428,7 +3427,7 @@ package body PSC.Trees.Semantics.Translator is
          begin
             if Op_Tree in Trees.Qualifier.Tree then
                Is_Not_Null := Trees.Qualifier.Tree
-                  (Op_Tree).Qualifiers (Trees.Qualifier.Is_Not_Null);
+                 (Op_Tree).Qualifiers (Trees.Qualifier.Is_Not_Null);
             end if;
          end;
       end if;
@@ -3447,7 +3446,7 @@ package body PSC.Trees.Semantics.Translator is
       Is_Mutable : Boolean := False;
       Target : constant Word_Type := Fetch_Word (Params, 0);
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -3455,7 +3454,7 @@ package body PSC.Trees.Semantics.Translator is
          begin
             if Op_Tree in Trees.Qualifier.Tree then
                Is_Mutable := Trees.Qualifier.Tree
-                  (Op_Tree).Qualifiers (Trees.Qualifier.Is_Mutable);
+                 (Op_Tree).Qualifiers (Trees.Qualifier.Is_Mutable);
             end if;
          end;
       end if;
@@ -3482,7 +3481,7 @@ package body PSC.Trees.Semantics.Translator is
          begin
             if Op_Tree in Trees.Qualifier.Tree then
                Is_Concurrent := Trees.Qualifier.Tree
-                  (Op_Tree).Qualifiers (Trees.Qualifier.Is_Concurrent);
+                 (Op_Tree).Qualifiers (Trees.Qualifier.Is_Concurrent);
             end if;
          end;
       end if;
@@ -3501,7 +3500,7 @@ package body PSC.Trees.Semantics.Translator is
       Is_Var : Boolean := False;
       Target : constant Word_Type := Fetch_Word (Params, 0);
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -3509,7 +3508,7 @@ package body PSC.Trees.Semantics.Translator is
          begin
             if Op_Tree in Trees.Qualifier.Tree then
                Is_Var := Trees.Qualifier.Tree
-                  (Op_Tree).Qualifiers (Trees.Qualifier.Is_Var);
+                 (Op_Tree).Qualifiers (Trees.Qualifier.Is_Var);
             end if;
          end;
       end if;
@@ -3528,7 +3527,7 @@ package body PSC.Trees.Semantics.Translator is
       Is_Const : Boolean := False;
       Target : constant Word_Type := Fetch_Word (Params, 0);
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -3536,7 +3535,7 @@ package body PSC.Trees.Semantics.Translator is
          begin
             if Op_Tree in Trees.Qualifier.Tree then
                Is_Const := Trees.Qualifier.Tree
-                  (Op_Tree).Qualifiers (Trees.Qualifier.Is_Const);
+                 (Op_Tree).Qualifiers (Trees.Qualifier.Is_Const);
             end if;
          end;
       end if;
@@ -3555,7 +3554,7 @@ package body PSC.Trees.Semantics.Translator is
       Is_Polymorphic : Boolean := False;
       Target : constant Word_Type := Fetch_Word (Params, 0);
       Op : constant Optional_Tree :=
-         To_Optional_Tree (Fetch_Word (Params, 1));
+        To_Optional_Tree (Fetch_Word (Params, 1));
    begin
       if Not_Null (Op) then
          declare
@@ -3563,7 +3562,7 @@ package body PSC.Trees.Semantics.Translator is
          begin
             if Op_Tree in Trees.Qualifier.Tree then
                Is_Polymorphic := Trees.Qualifier.Tree
-                  (Op_Tree).Qualifiers (Trees.Qualifier.Is_Polymorphic);
+                 (Op_Tree).Qualifiers (Trees.Qualifier.Is_Polymorphic);
             end if;
          end;
       end if;

--- a/semantics/psc-trees-semantics-translator.adb
+++ b/semantics/psc-trees-semantics-translator.adb
@@ -550,6 +550,24 @@ package body PSC.Trees.Semantics.Translator is
       Static_Link : Non_Op_Map_Type_Ptr);
    pragma Export (Ada, Tree_Qualifier_Is_Polymorphic, "_psc_tree_qualifier_is_polymorphic");
 
+   procedure Tree_Case_Num_Alts
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Case_Num_Alts, "_psc_tree_case_num_alts");
+
+   procedure Tree_For_Loop_Num_Iters
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_For_Loop_Num_Iters, "_psc_tree_for_loop_num_iters");
+
+   procedure Tree_For_Loop_Num_Prologue
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_For_Loop_Num_Prologue, "_psc_tree_for_loop_num_prologue");
+
    procedure Tree_Source_Pos
      (Context : in out Exec_Context;
       Params : Word_Ptr;
@@ -3571,6 +3589,87 @@ package body PSC.Trees.Semantics.Translator is
         (Params, 0,
          Boolean'Pos (Is_Polymorphic));
    end Tree_Qualifier_Is_Polymorphic;
+
+   procedure Tree_Case_Num_Alts
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Case_Num_Alts(Tree {Kind(Tree) == #case_construct}) -> Natural
+      --     is import(#tree_case_num_alts)
+      Alt_Count : Natural := 0;
+      Target : constant Word_Type := Fetch_Word (Params, 0);
+      Op : constant Optional_Tree :=
+        To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Case_Construct.Tree then
+               Alt_Count := Trees.Lists.Length (Trees.Case_Construct.Tree
+                 (Op_Tree).Case_Alt_List);
+            end if;
+         end;
+      end if;
+
+      Store_Word
+        (Params, 0,
+         Word_Type (Alt_Count));
+   end Tree_Case_Num_Alts;
+
+   procedure Tree_For_Loop_Num_Iters
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func For_Loop_Num_Iters(Tree {Kind(Tree) == #for_loop}) -> Natural
+      --     is import(#tree_for_loop_num_iters)
+      Iter_Count : Natural := 0;
+      Target : constant Word_Type := Fetch_Word (Params, 0);
+      Op : constant Optional_Tree :=
+        To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.For_Loop_Construct.Tree then
+               Iter_Count := Trees.Lists.Length (Trees.For_Loop_Construct.Tree
+                 (Op_Tree).Iterators);
+            end if;
+         end;
+      end if;
+
+      Store_Word
+        (Params, 0,
+         Word_Type (Iter_Count));
+   end Tree_For_Loop_Num_Iters;
+
+   procedure Tree_For_Loop_Num_Prologue
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func For_Loop_Num_Prologue(Tree {Kind(Tree) == #for_loop}) -> Natural
+      --     is import(#tree_for_loop_num_prologue)
+      Iter_Count : Natural := 0;
+      Target : constant Word_Type := Fetch_Word (Params, 0);
+      Op : constant Optional_Tree :=
+        To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.For_Loop_Construct.Tree then
+               Iter_Count := Trees.Lists.Length (Trees.For_Loop_Construct.Tree
+                 (Op_Tree).Prologue);
+            end if;
+         end;
+      end if;
+
+      Store_Word
+        (Params, 0,
+         Word_Type (Iter_Count));
+   end Tree_For_Loop_Num_Prologue;
 
    procedure Decl_Region
      (Context : in out Exec_Context;
@@ -7203,6 +7302,18 @@ begin  --  PSC.Trees.Semantics.Translator;
    Interpreter.Builtins.Register_Builtin
      (Strings.String_Lookup ("#tree_qualifier_is_polymorphic"),
       Tree_Qualifier_Is_Polymorphic'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_case_num_alts"),
+      Tree_Case_Num_Alts'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_for_loop_num_iters"),
+      Tree_For_Loop_Num_Iters'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_for_loop_num_prologue"),
+      Tree_For_Loop_Num_Prologue'Access);
 
    Interpreter.Builtins.Register_Builtin
      (Strings.String_Lookup ("#tree_source_pos"),

--- a/semantics/psc-trees-semantics-translator.adb
+++ b/semantics/psc-trees-semantics-translator.adb
@@ -46,6 +46,7 @@ with PSC.Trees.Iterator;
 with PSC.Trees.Obj_Decl;
 with PSC.Trees.Operation;
 with PSC.Trees.Param_Decl;
+with PSC.Trees.Qualifier;
 with PSC.Trees.Unary;
 
 with Ada.Text_IO; use Ada.Text_IO;
@@ -494,6 +495,60 @@ package body PSC.Trees.Semantics.Translator is
       Params : Word_Ptr;
       Static_Link : Non_Op_Map_Type_Ptr);
    pragma Export (Ada, Tree_Obj_Decl_Is_Global, "_psc_tree_obj_decl_is_global");
+
+   procedure Tree_Qualifier_Is_Ref
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Qualifier_Is_Ref, "_psc_tree_qualifier_is_ref");
+
+   procedure Tree_Qualifier_Is_Abstract
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Qualifier_Is_Abstract, "_psc_tree_qualifier_is_abstract");
+
+   procedure Tree_Qualifier_Is_Optional
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Qualifier_Is_Optional, "_psc_tree_qualifier_is_optional");
+
+   procedure Tree_Qualifier_Is_Not_Null
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Qualifier_Is_Not_Null, "_psc_tree_qualifier_is_not_null");
+
+   procedure Tree_Qualifier_Is_Mutable
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Qualifier_Is_Mutable, "_psc_tree_qualifier_is_mutable");
+
+   procedure Tree_Qualifier_Is_Concurrent
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Qualifier_Is_Concurrent, "_psc_tree_qualifier_is_concurrent");
+
+   procedure Tree_Qualifier_Is_Var
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Qualifier_Is_Var, "_psc_tree_qualifier_is_var");
+
+   procedure Tree_Qualifier_Is_Const
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Qualifier_Is_Const, "_psc_tree_qualifier_is_const");
+
+   procedure Tree_Qualifier_Is_Polymorphic
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Qualifier_Is_Polymorphic, "_psc_tree_qualifier_is_polymorphic");
 
    procedure Tree_Source_Pos
      (Context : in out Exec_Context;
@@ -3274,6 +3329,249 @@ package body PSC.Trees.Semantics.Translator is
         (Params, 0,
          Boolean'Pos (Is_Global));
    end Tree_Obj_Decl_Is_Global;
+
+   procedure Tree_Qualifier_Is_Ref
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Qualifier_Is_Ref(Tree {Kind(Tree) == #qualifier}) -> Boolean
+      --    is import(#tree_qualifier_is_ref)
+      Is_Ref : Boolean := False;
+      Target : constant Word_Type := Fetch_Word (Params, 0);
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Qualifier.Tree then
+               Is_Ref := Trees.Qualifier.Tree
+                  (Op_Tree).Qualifiers (Trees.Qualifier.Is_Ref);
+            end if;
+         end;
+      end if;
+
+      Store_Word
+        (Params, 0,
+         Boolean'Pos (Is_Ref));
+   end Tree_Qualifier_Is_Ref;
+
+   procedure Tree_Qualifier_Is_Abstract
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Qualifier_Is_Abstract(Tree {Kind(Tree) == #qualifier}) -> Boolean
+      --    is import(#tree_qualifier_is_abstract)
+      Is_Abstract : Boolean := False;
+      Target : constant Word_Type := Fetch_Word (Params, 0);
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Qualifier.Tree then
+               Is_Abstract := Trees.Qualifier.Tree
+                  (Op_Tree).Qualifiers (Trees.Qualifier.Is_Abstract);
+            end if;
+         end;
+      end if;
+
+      Store_Word
+        (Params, 0,
+         Boolean'Pos (Is_Abstract));
+   end Tree_Qualifier_Is_Abstract;
+
+   procedure Tree_Qualifier_Is_Optional
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Qualifier_Is_Optional(Tree {Kind(Tree) == #qualifier}) -> Boolean
+      --    is import(#tree_qualifier_is_optional)
+      Is_Optional : Boolean := False;
+      Target : constant Word_Type := Fetch_Word (Params, 0);
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Qualifier.Tree then
+               Is_Optional := Trees.Qualifier.Tree
+                  (Op_Tree).Qualifiers (Trees.Qualifier.Is_Optional);
+            end if;
+         end;
+      end if;
+
+      Store_Word
+        (Params, 0,
+         Boolean'Pos (Is_Optional));
+   end Tree_Qualifier_Is_Optional;
+
+   procedure Tree_Qualifier_Is_Not_Null
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Qualifier_Is_Not_Null(Tree {Kind(Tree) == #qualifier}) -> Boolean
+      --    is import(#tree_qualifier_is_not_null)
+      Is_Not_Null : Boolean := False;
+      Target : constant Word_Type := Fetch_Word (Params, 0);
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Qualifier.Tree then
+               Is_Not_Null := Trees.Qualifier.Tree
+                  (Op_Tree).Qualifiers (Trees.Qualifier.Is_Not_Null);
+            end if;
+         end;
+      end if;
+
+      Store_Word
+        (Params, 0,
+         Boolean'Pos (Is_Not_Null));
+   end Tree_Qualifier_Is_Not_Null;
+
+   procedure Tree_Qualifier_Is_Mutable
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Qualifier_Is_Mutable(Tree {Kind(Tree) == #qualifier}) -> Boolean
+      --    is import(#tree_qualifier_is_mutable)
+      Is_Mutable : Boolean := False;
+      Target : constant Word_Type := Fetch_Word (Params, 0);
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Qualifier.Tree then
+               Is_Mutable := Trees.Qualifier.Tree
+                  (Op_Tree).Qualifiers (Trees.Qualifier.Is_Mutable);
+            end if;
+         end;
+      end if;
+
+      Store_Word
+        (Params, 0,
+         Boolean'Pos (Is_Mutable));
+   end Tree_Qualifier_Is_Mutable;
+
+   procedure Tree_Qualifier_Is_Concurrent
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Qualifier_Is_Concurrent(Tree {Kind(Tree) == #qualifier}) -> Boolean
+      --    is import(#tree_qualifier_is_concurrent)
+      Is_Concurrent : Boolean := False;
+      Target : constant Word_Type := Fetch_Word (Params, 0);
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Qualifier.Tree then
+               Is_Concurrent := Trees.Qualifier.Tree
+                  (Op_Tree).Qualifiers (Trees.Qualifier.Is_Concurrent);
+            end if;
+         end;
+      end if;
+
+      Store_Word
+        (Params, 0,
+         Boolean'Pos (Is_Concurrent));
+   end Tree_Qualifier_Is_Concurrent;
+
+   procedure Tree_Qualifier_Is_Var
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Qualifier_Is_Var(Tree {Kind(Tree) == #qualifier}) -> Boolean
+      --    is import(#tree_qualifier_is_var)
+      Is_Var : Boolean := False;
+      Target : constant Word_Type := Fetch_Word (Params, 0);
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Qualifier.Tree then
+               Is_Var := Trees.Qualifier.Tree
+                  (Op_Tree).Qualifiers (Trees.Qualifier.Is_Var);
+            end if;
+         end;
+      end if;
+
+      Store_Word
+        (Params, 0,
+         Boolean'Pos (Is_Var));
+   end Tree_Qualifier_Is_Var;
+
+   procedure Tree_Qualifier_Is_Const
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Qualifier_Is_Const(Tree {Kind(Tree) == #qualifier}) -> Boolean
+      --    is import(#tree_qualifier_is_const)
+      Is_Const : Boolean := False;
+      Target : constant Word_Type := Fetch_Word (Params, 0);
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Qualifier.Tree then
+               Is_Const := Trees.Qualifier.Tree
+                  (Op_Tree).Qualifiers (Trees.Qualifier.Is_Const);
+            end if;
+         end;
+      end if;
+
+      Store_Word
+        (Params, 0,
+         Boolean'Pos (Is_Const));
+   end Tree_Qualifier_Is_Const;
+
+   procedure Tree_Qualifier_Is_Polymorphic
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Qualifier_Is_Polymorphic(Tree {Kind(Tree) == #qualifier}) -> Boolean
+      --    is import(#tree_qualifier_is_polymorphic)
+      Is_Polymorphic : Boolean := False;
+      Target : constant Word_Type := Fetch_Word (Params, 0);
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Qualifier.Tree then
+               Is_Polymorphic := Trees.Qualifier.Tree
+                  (Op_Tree).Qualifiers (Trees.Qualifier.Is_Polymorphic);
+            end if;
+         end;
+      end if;
+
+      Store_Word
+        (Params, 0,
+         Boolean'Pos (Is_Polymorphic));
+   end Tree_Qualifier_Is_Polymorphic;
 
    procedure Decl_Region
      (Context : in out Exec_Context;
@@ -6870,6 +7168,42 @@ begin  --  PSC.Trees.Semantics.Translator;
    Interpreter.Builtins.Register_Builtin
      (Strings.String_Lookup ("#tree_obj_decl_is_global"),
       Tree_Obj_Decl_Is_Global'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_qualifier_is_ref"),
+      Tree_Qualifier_Is_Ref'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_qualifier_is_abstract"),
+      Tree_Qualifier_Is_Abstract'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_qualifier_is_optional"),
+      Tree_Qualifier_Is_Optional'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_qualifier_is_not_null"),
+      Tree_Qualifier_Is_Not_Null'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_qualifier_is_mutable"),
+      Tree_Qualifier_Is_Mutable'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_qualifier_is_concurrent"),
+      Tree_Qualifier_Is_Concurrent'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_qualifier_is_var"),
+      Tree_Qualifier_Is_Var'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_qualifier_is_const"),
+      Tree_Qualifier_Is_Const'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_qualifier_is_polymorphic"),
+      Tree_Qualifier_Is_Polymorphic'Access);
 
    Interpreter.Builtins.Register_Builtin
      (Strings.String_Lookup ("#tree_source_pos"),

--- a/semantics/psc-trees-semantics-translator.adb
+++ b/semantics/psc-trees-semantics-translator.adb
@@ -34,9 +34,18 @@ with PSC.Trees.Semantics.Info;
 with PSC.Trees.Semantics.Static;
 with PSC.Univ_Strings;
 
-with PSC.Trees.Unary;
+with PSC.Trees.Assign_Stmt;
 with PSC.Trees.Binary;
+with PSC.Trees.Conditional;
+with PSC.Trees.Control_Stmt;
+with PSC.Trees.For_Loop_Construct;
+with PSC.Trees.Operation;
+with PSC.Trees.Unary;
 with PSC.Trees.Identifier;
+with PSC.Trees.Invocation;
+with PSC.Trees.Iterator;
+
+with Ada.Text_IO; use Ada.Text_IO;
 
 pragma Elaborate_All (PSC.Interpreter.Builtins);
 pragma Elaborate_All (PSC.Strings);
@@ -392,6 +401,54 @@ package body PSC.Trees.Semantics.Translator is
       Params : Word_Ptr;
       Static_Link : Non_Op_Map_Type_Ptr);
    pragma Export (Ada, Tree_Binary_Op, "_psc_tree_binary_op");
+
+   procedure Tree_Assignment_Op
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Assignment_Op, "_psc_tree_assignnent_op");
+
+   procedure Tree_Conditional_Kind
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Conditional_Kind, "_psc_tree_conditional_kind");
+
+   procedure Tree_Control_Stmt_Kind
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Control_Stmt_Kind, "_psc_tree_control_stmt_kind");
+
+   procedure Tree_Applies_To
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Applies_To, "_psc_tree_applies_to");
+
+   procedure Tree_For_Loop_Kind
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_For_Loop_Kind, "_psc_tree_for_loop_kind");
+
+   procedure Tree_Invocation_Kind
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Invocation_Kind, "_psc_tree_invocation_kind");
+
+   procedure Tree_Iterator_Kind
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Iterator_Kind, "_psc_tree_iterator_kind");
+
+   procedure Tree_Operation_Kind
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Tree_Operation_Kind, "_psc_tree_operation_kind");
 
    procedure Tree_Source_Pos
      (Context : in out Exec_Context;
@@ -2639,6 +2696,258 @@ package body PSC.Trees.Semantics.Translator is
       Store_Word
          (Params, 0, Null_Value);
    end Tree_Binary_Op;
+
+   procedure Tree_Assignment_Op
+      (Context : in out Exec_Context;
+       Params : Word_Ptr;
+       Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Assignment_Op(Tree {Kind(Tree) == #assign_stmt}) -> Assign_Op_Kind
+      --    is import(#tree_assignment_op)
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Assign_Stmt.Tree'Class then
+               declare
+                  Assign_Tree : constant Trees.Assign_Stmt.Tree :=
+                     Trees.Assign_Stmt.Tree (Op_Tree);
+                  Index : Word_Type := Trees.Assign_Stmt.Assign_Operator_Enum'Pos
+                     (Assign_Tree.Assign_Operator);
+               begin
+                  Store_Word (Params, 0, Index);
+                  return;
+               end;
+            end if;
+         end;
+      end if;
+
+      Store_Word
+         (Params, 0, Null_Value);
+   end Tree_Assignment_Op;
+
+   ---------------------------
+   -- Tree_Conditional_Kind --
+   ---------------------------
+
+   procedure Tree_Conditional_Kind
+      (Context : in out Exec_Context;
+       Params : Word_Ptr;
+       Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Get_Conditional_Kind(Tree {Kind(Tree) == #conditional})
+      --    -> Conditional_Kind import(#tree_conditional_kind)
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Conditional.Tree'Class then
+               declare
+                  Cond_Tree : constant Trees.Conditional.Tree :=
+                     Trees.Conditional.Tree (Op_Tree);
+                  Index : Word_Type := Trees.Conditional.Conditional_Kind_Enum'Pos
+                     (Cond_Tree.Kind);
+               begin
+                  Store_Word (Params, 0, Index);
+                  return;
+               end;
+            end if;
+         end;
+      end if;
+
+      Store_Word
+         (Params, 0, Null_Value);
+   end Tree_Conditional_Kind;
+
+   procedure Tree_Control_Stmt_Kind
+      (Context : in out Exec_Context;
+       Params : Word_Ptr;
+       Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Get_Control_Stmt_Kind(Tree {Kind(Tree) == #control_stmt}) -> Control_Stmt_Kind
+      --    is import(#tree_control_stmt_kind)
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Control_Stmt.Tree'Class then
+               declare
+                  Ctrl_Tree : constant Trees.Control_Stmt.Tree :=
+                     Trees.Control_Stmt.Tree (Op_Tree);
+                  Index : Word_Type := Trees.Control_Stmt.Control_Stmt_Enum'Pos
+                     (Ctrl_Tree.Kind);
+               begin
+                  Store_Word (Params, 0, Index);
+                  return;
+               end;
+            end if;
+         end;
+      end if;
+
+      Store_Word
+         (Params, 0, Null_Value);
+   end Tree_Control_Stmt_Kind;
+
+   procedure Tree_Applies_To
+      (Context : in out Exec_Context;
+       Params : Word_Ptr;
+       Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Applies_To(Tree {Kind(Tree) == #control_stmt}) -> Exitable_Construct_Kind
+      --    is import(#tree_applies_to)
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Control_Stmt.Tree'Class then
+               declare
+                  AT_Tree : constant Trees.Control_Stmt.Tree :=
+                     Trees.Control_Stmt.Tree (Op_Tree);
+                  Index : Word_Type := Trees.Control_Stmt.Exitable_Construct_Enum'Pos
+                     (AT_Tree.Applies_To);
+               begin
+                  Store_Word (Params, 0, Index);
+                  return;
+               end;
+            end if;
+         end;
+      end if;
+
+      Store_Word
+         (Params, 0, Null_Value);
+   end Tree_Applies_To;
+
+   procedure Tree_For_Loop_Kind
+      (Context : in out Exec_Context;
+       Params : Word_Ptr;
+       Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func For_Loop_Kind(Tree {Kind(Tree) == #for_loop}) -> For_Loop_Kind_Enum
+      --    is import(#tree_for_loop_kind)
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.For_Loop_Construct.Tree'Class then
+               declare
+                  Loop_Tree : constant Trees.For_Loop_Construct.Tree :=
+                     Trees.For_Loop_Construct.Tree (Op_Tree);
+                  Index : Word_Type := Trees.For_Loop_Construct.For_Loop_Kind_Enum'Pos
+                     (Loop_Tree.Kind);
+               begin
+                  Store_Word (Params, 0, Index);
+                  return;
+               end;
+            end if;
+         end;
+      end if;
+
+      Store_Word
+         (Params, 0, Null_Value);
+   end Tree_For_Loop_Kind;
+
+   procedure Tree_Invocation_Kind
+      (Context : in out Exec_Context;
+       Params : Word_Ptr;
+       Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Invocation_Kind(Tree {Kind(Tree) == #invocation}) -> Invocation_Kind_Enum
+      --    is import(#tree_invocation_kind)
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Invocation.Tree'Class then
+               declare
+                  Invoc_Tree : constant Trees.Invocation.Tree :=
+                     Trees.Invocation.Tree (Op_Tree);
+                  Index : Word_Type := Trees.Invocation.Invocation_Kind_Enum'Pos
+                     (Invoc_Tree.Kind);
+               begin
+                  Store_Word (Params, 0, Index);
+                  return;
+               end;
+            end if;
+         end;
+      end if;
+
+      Store_Word
+         (Params, 0, Null_Value);
+   end Tree_Invocation_Kind;
+
+   procedure Tree_Iterator_Kind
+      (Context : in out Exec_Context;
+       Params : Word_Ptr;
+       Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Iterator_Kind(Tree {Kind(Tree) == #iterator}) -> Iterator_Kind_Enum
+      --    is import(#tree_iterator_kind)
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Iterator.Tree'Class then
+               declare
+                  Iter_Tree : constant Trees.Iterator.Tree :=
+                     Trees.Iterator.Tree (Op_Tree);
+                  Index : Word_Type := Trees.Iterator.Iterator_Kind_Enum'Pos
+                     (Iter_Tree.Kind);
+               begin
+                  Store_Word (Params, 0, Index);
+                  return;
+               end;
+            end if;
+         end;
+      end if;
+
+      Store_Word
+         (Params, 0, Null_Value);
+   end Tree_Iterator_Kind;
+
+   procedure Tree_Operation_Kind
+      (Context : in out Exec_Context;
+       Params : Word_Ptr;
+       Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Operation_Kind(Tree {Kind(Tree) == #operation}) -> Operation_Kind_Enum
+      --    is import(#tree_operation_kind)
+      Op : constant Optional_Tree :=
+         To_Optional_Tree (Fetch_Word (Params, 1));
+   begin
+      if Not_Null (Op) then
+         declare
+            Op_Tree : Tree'Class renames Tree_Ptr_Of (Op).all;
+         begin
+            if Op_Tree in Trees.Operation.Tree'Class then
+               declare
+                  Operand_Tree : constant Trees.Operation.Tree :=
+                     Trees.Operation.Tree (Op_Tree);
+                  Index : Word_Type := Trees.Operation.Operation_Kind_Enum'Pos
+                     (Operand_Tree.Operation_Kind);
+               begin
+                  Store_Word (Params, 0, Index);
+                  return;
+               end;
+            end if;
+         end;
+      end if;
+
+      Store_Word
+         (Params, 0, Null_Value);
+   end Tree_Operation_Kind;
 
    procedure Tree_Lit_Kind
       (Context : in out Exec_Context;
@@ -6222,6 +6531,38 @@ begin  --  PSC.Trees.Semantics.Translator;
    Interpreter.Builtins.Register_Builtin
      (Strings.String_Lookup ("#tree_binary_op"),
       Tree_Binary_Op'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_assignment_op"),
+      Tree_Assignment_Op'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_conditional_kind"),
+      Tree_Conditional_Kind'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_control_stmt_kind"),
+      Tree_Control_Stmt_Kind'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_applies_to"),
+      Tree_Applies_To'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_for_loop_kind"),
+      Tree_For_Loop_Kind'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_invocation_kind"),
+      Tree_Invocation_Kind'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_iterator_kind"),
+      Tree_Iterator_Kind'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#tree_operation_kind"),
+      Tree_Operation_Kind'Access);
 
    Interpreter.Builtins.Register_Builtin
      (Strings.String_Lookup ("#tree_lit_kind"),

--- a/semantics/psc-trees-while_stmt.adb
+++ b/semantics/psc-trees-while_stmt.adb
@@ -58,7 +58,7 @@ package body PSC.Trees.While_Stmt is
          when 1 =>
             return T.While_Cond;
          when 2 =>
-            return T.Loop_Body;  --  TBD: Is this useful?
+            return T.Loop_Body;
          when others =>
             pragma Assert (N <= 2);
             return Null_Optional_Tree;
@@ -75,7 +75,7 @@ package body PSC.Trees.While_Stmt is
          when 1 =>
             T.While_Cond := New_Operand;
          when 2 =>
-            T.Loop_Body := New_Operand;  --  TBD: Is this useful?
+            T.Loop_Body := New_Operand;
          when others =>
             pragma Assert (N <= 2);
             return;


### PR DESCRIPTION
This pull request makes the following changes to the Tree reflection API:
- Exposes multiple kind enums (e.g. `Assign_Op_Kind_Enum`, `Conditional_Kind_Enum`) that convey Tree-Kind-specific type information. Each new enumeration corresponds to one in ParaSail's semantic tree library.
- Labeled indexes for trees with static operand indices. These convenience values can be used to access known operands (e.g. `Bin_Op.Nth_Operand(Tree::Binary_Left_Op)`)
- Size data for tree kinds without static indexes. These sizes can be used to determine the index ranges of different "regions" of the tree.
- Boolean access methods for Qualifier and Obj_Decls.