### PR TITLE
[Reflection] Tighten checks on Resolved_Type

### DIFF
--- a/lib/reflection.psi
+++ b/lib/reflection.psi
@@ -565,6 +565,8 @@ interface PSC::Reflection<> is
 
         func Tree_Of(Decl) -> Tree
           is import(#decl_tree_of)
+        func Associated_Module(Decl {Kind(Decl) == #type}) -> optional Decl
+          is import(#decl_associated_module)
 
         func Location(Decl) -> Object_Locator  //  Rename routine
           is in Object_Locator

--- a/lib/reflection.psi
+++ b/lib/reflection.psi
@@ -183,7 +183,7 @@ interface PSC::Reflection<> is
          #times_assign_op, #divide_assign_op, #power_assign_op,
          #combine_assign_op, #ampersand_assign_op, #and_assign_op,
          #or_assign_op, #xor_assign_op, #left_shift_assign_op,
-         #right_shift_assign_op, #swap_op, #move_op, #combine_move_o4p]>
+         #right_shift_assign_op, #swap_op, #move_op, #combine_move_op]>
       type Literal_Kind_Enum is Enum<
         [#integer_literal, #real_literal, #string_literal,
          #char_literal, #enum_literal, #null_literal]>;

--- a/semantics/psc-trees-semantics-translator.adb
+++ b/semantics/psc-trees-semantics-translator.adb
@@ -2731,7 +2731,12 @@ package body PSC.Trees.Semantics.Translator is
             Res_Type : constant Type_Sem_Ptr :=
               Resolved_Type (Op);
          begin
-            if Res_Type /= null then
+            if Res_Type /= null and then Res_Type.U_Base_Type /= null
+              and then
+                Res_Type.U_Base_Type.Type_Descriptor_Location.Base = Zero_Base
+              and then
+                Res_Type.U_Base_Type.Type_Descriptor_Location.Offset /= 0
+            then
                Store_Word
                  (Params, 0,
                   To_Word_Type (Get_Type_Desc

--- a/semantics/psc-trees-semantics-translator.adb
+++ b/semantics/psc-trees-semantics-translator.adb
@@ -207,6 +207,12 @@ package body PSC.Trees.Semantics.Translator is
       Static_Link : Non_Op_Map_Type_Ptr);
    pragma Export (Ada, Decl_Tree_Of, "_psc_decl_tree_of");
 
+   procedure Decl_Associated_Module
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr);
+   pragma Export (Ada, Decl_Associated_Module, "_psc_decl_associated_module");
+
    procedure Decl_Component_Index
      (Context : in out Exec_Context;
       Params : Word_Ptr;
@@ -1946,6 +1952,31 @@ package body PSC.Trees.Semantics.Translator is
       Store_Word
         (Params, 0, To_Word_Type (Result_Op));
    end Decl_Tree_Of;
+
+   procedure Decl_Associated_Module
+     (Context : in out Exec_Context;
+      Params : Word_Ptr;
+      Static_Link : Non_Op_Map_Type_Ptr) is
+      --  func Associated_Module(Decl {Kind(Decl) == #type}) -> optional Decl
+      --    is import(#decl_associated_module)
+      Decl_Sem : Root_Semantic_Info'Class renames
+        To_Root_Sem_Ptr (Fetch_Word (Params, 1)).all;
+      Result_Op : constant Optional_Tree := Decl_Sem.Definition;
+   begin
+      if Decl_Sem in Type_Semantic_Info'Class then
+         declare
+            Type_Sem : Type_Semantic_Info'Class renames
+              Type_Semantic_Info'Class (Decl_Sem);
+         begin
+            Store_Word
+              (Params, 0, To_Word_Type
+               (Root_Sem_Ptr (Type_Sem.Associated_Module)));
+         end;
+      else
+         Store_Word
+           (Params, 0, To_Word_Type (Result_Op));
+      end if;
+   end Decl_Associated_Module;
 
    procedure Decl_Location
      (Context : in out Exec_Context;
@@ -6930,6 +6961,10 @@ begin  --  PSC.Trees.Semantics.Translator;
    Interpreter.Builtins.Register_Builtin
      (Strings.String_Lookup ("#decl_tree_of"),
       Decl_Tree_Of'Access);
+
+   Interpreter.Builtins.Register_Builtin
+     (Strings.String_Lookup ("#decl_associated_module"),
+      Decl_Associated_Module'Access);
 
    Interpreter.Builtins.Register_Builtin
      (Strings.String_Lookup ("#decl_location"),


### PR DESCRIPTION
`Resolved_Type` sometimes crashes when it should instead return null. This pull request tightens the checks in `Tree_Resolved_Type` so they are in line with the checks in `Descriptor_For_Type`. It also fixes a typo in `#combine_move_op`.