### PR TITLE
[Reflection] Add formal access to type decls + symbol API

### DIFF
--- a/lib/reflection.psi
+++ b/lib/reflection.psi
@@ -154,6 +154,7 @@ interface PSC::Reflection<> is
  
     end interface Environment
 
+    // Raw access to ParaSail's AST
     interface Tree<> is
       type Tree_Kind_Enum is Enum<
         [#annotation, #assign_stmt, #binary,
@@ -276,6 +277,8 @@ interface PSC::Reflection<> is
         is import(#tree_source_pos)
       func Resolved_Type(Tree) -> optional Type_Descriptor
         is import(#tree_resolved_type)
+      func Sem_Info(Tree) -> optional Decl
+        is import(#tree_sem_info)
       func Resolved_Interp(Tree) -> optional Tree
         is import(#tree_resolved_interp)
       func Decl_Of(Tree) -> optional Decl

--- a/lib/reflection.psi
+++ b/lib/reflection.psi
@@ -154,6 +154,25 @@ interface PSC::Reflection<> is
  
     end interface Environment
 
+    interface Symbol<> is
+      type Symbol_Kind_Enum is Enum<[#no_sym_kind, #module_sym_kind,
+        #module_ancestor_sym_kind, #type_sym_kind, #param_sym_kind,
+        #loop_param_sym_kind, #loop_key_param_sym_kind, #object_sym_kind,
+        #component_sym_kind, #operation_sym_kind, #literal_sym_kind,
+        #statement_sym_kind]>
+
+      func Kind(Symbol) -> Symbol_Kind_Enum
+        is import(#symbol_kind)
+      func Definition(Symbol) -> Tree
+        is import(#symbol_definition)
+      func Source_Pos(Symbol) -> optional Source_Position
+        is import(#symbol_source_pos)
+      func Str(Symbol) -> Univ_String
+        is import(#symbol_str)
+      func Full_Name(Symbol) -> Univ_String
+        is import(#symbol_full_name)
+    end interface Symbol
+
     // Raw access to ParaSail's AST
     interface Tree<> is
       type Tree_Kind_Enum is Enum<
@@ -331,6 +350,8 @@ interface PSC::Reflection<> is
 
       func Call_Operation(Tree) -> optional Decl
         is import(#tree_call_operation)
+      func Symbol(Tree) -> optional Symbol
+        is import(#tree_symbol)
 
       func Qualifier_Is_Ref(Tree {Kind(Tree) == #qualifier}) -> Boolean
         is import(#tree_qualifier_is_ref)

--- a/lib/reflection.psi
+++ b/lib/reflection.psi
@@ -15,7 +15,7 @@ interface PSC::Info_Array<Elem_Type is Assignable<>;
         #type_desc_stream, #op_map,
         #routine_parameters, #routine_uplevel_refs,
         #string_stream, #const_value_stream,
-        #large_const_component_values]>
+        #large_const_component_values, #trees_of_actuals]>
       //  Kinds of info-arrays available for a Type_Descriptor, Routine, 
       //  Univ_String, or Element_Info.
 
@@ -600,6 +600,10 @@ interface PSC::Reflection<> is
           {Base(Location(Decl)) == Object_Locator::Const_Area}
           -> optional Streamable_Value
           is import(#global_const_value)
+
+        func Trees_Of_Actuals(Decl {Kind(Decl) == #type})
+          -> Info_Array<Tree, Decl, Indexed_By => Univ_Integer>
+          is (Decl, #trees_of_actuals)
 
         //  Operations needed to be Hashable
         func Hash(Val : Decl) -> Unsigned_64 is import(#identity)

--- a/semantics/psc-trees-semantics-translator.adb
+++ b/semantics/psc-trees-semantics-translator.adb
@@ -1589,7 +1589,7 @@ package body PSC.Trees.Semantics.Translator is
      Components_Kind, Nested_Types_Kind, Nested_Objs_Kind, Operations_Kind,
      Type_Desc_Stream_Kind, Op_Map_Kind, Routine_Parameters_Kind,
      Routine_Uplevel_Refs_Kind, String_Stream_Kind, Const_Value_Stream_Kind,
-     Large_Const_Component_Values);
+     Large_Const_Component_Values, Trees_Of_Actuals_Kind);
 
    package PFS renames Per_File_Strings;
 
@@ -6381,6 +6381,20 @@ package body PSC.Trees.Semantics.Translator is
             end case;
          end;
 
+      when Trees_Of_Actuals_Kind =>
+         declare
+            Root_Sem : constant Root_Sem_Ptr := To_Root_Sem_Ptr (Entity);
+         begin
+            if Root_Sem /= null and then Root_Sem.all in
+              Type_Semantic_Info'Class and then Type_Sem_Ptr
+               (Root_Sem).Actual_Sem_Infos /= null
+            then
+               Result := Type_Sem_Ptr (Root_Sem).Actual_Sem_Infos'Length;
+            else
+               Result := 0;
+            end if;
+         end;
+
       when String_Stream_Kind =>
          declare
             Univ_Str : constant Univ_Strings.Univ_String :=
@@ -6821,6 +6835,15 @@ package body PSC.Trees.Semantics.Translator is
 
                end;
             end case;
+         end;
+
+      when Trees_Of_Actuals_Kind =>
+         declare
+            Root_Sem : constant Root_Sem_Ptr := To_Root_Sem_Ptr (Entity);
+            Actuals : constant Sem_Info_Array_Ptr :=
+               Type_Sem_Ptr (Root_Sem).Actual_Sem_Infos;
+         begin
+            Result := To_Word_Type (Actuals (Index).Definition);
          end;
 
       when String_Stream_Kind =>


### PR DESCRIPTION
This pull request gives the user access to the trees for a type's actuals. It also exposes the "Symbol" type.