### PR TITLE
Fix LLVM bootstrap on modern Linux (PIE relocation errors)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ OBJS=
 EXE=compiled_main.exe
 A2X_EXE=compiled_a2x_main.exe
 OMPLIB=-lgomp
-MATHLIB=-lm
+MATHLIB=-lm -no-pie
 
 ifeq ($(OMP),on)
   EXTRALIBS=$(OMPLIB)

--- a/bin/pslc.csh
+++ b/bin/pslc.csh
@@ -399,7 +399,7 @@ foreach i ($to_be_compiled)
       exit "$status"
    endif
 
-   clang -c $debug_asm $i.s -o $i.o
+   clang -c -fPIC $debug_asm $i.s -o $i.o
    if ("$status" != 0) then
       exit "$status"
    endif

--- a/compiler_llvm_tests/test_it.sh
+++ b/compiler_llvm_tests/test_it.sh
@@ -1,34 +1,15 @@
-# edit this to point to your ParaSail top directory
 ParaSail='../'
+PSLC=$ParaSail'bin/pslc.csh'
 
-bin='build/bin/parasail_main'
-aaa='examples/aaa/aaa*.ps?'
-reflection='examples/reflection.ps?'
-llvm='examples/llvm_printer.ps?'
-compiler='examples/compiler.ps?'
+# Clean up
+rm -f *.o *.s *.ll a.out
 
-pslc_local() {
-   $ParaSail$bin $ParaSail$aaa $ParaSail$reflection $ParaSail$llvm $ParaSail$compiler "$@" -command Compile "$@"
-}
+# compile all tests to .o using INTERPRETER (-i) for stability
+$PSLC -i -k abs.psl a.psl cmp.psl fact.psl float_cmp.psl identity.psl less_than.psl mod.psl max.psl null.psl one.psl ops.psl fib.psl prime.psl real_int_mult.psl exp.psl main.psl
 
-pslc_local abs.psl a.psl cmp.psl fact.psl float_cmp.psl identity.psl less_than.psl mod.psl max.psl null.psl one.psl ops.psl fib.psl prime.psl real_int_mult.psl exp.psl main.psl
-llc main.psl.ll
-llc abs.psl.ll
-llc a.psl.ll
-llc cmp.psl.ll
-llc fact.psl.ll
-llc float_cmp.psl.ll
-llc identity.psl.ll
-llc less_than.psl.ll
-llc mod.psl.ll
-llc max.psl.ll
-llc null.psl.ll
-llc one.psl.ll
-llc ops.psl.ll
-llc fib.psl.ll
-llc prime.psl.ll
-llc real_int_mult.psl.ll
-llc exp.psl.ll
-clang -c -g *.s
-cd ..; make compiled_main OBJS="compiler_llvm_tests/*.o" EXE="compiler_llvm_tests/a.out"
-cd compiler_llvm_tests; ./a.out | diff correct.txt -
+# Link
+(cd .. && make --silent compiled_main OBJS="compiler_llvm_tests/*.o" EXE="a.out")
+mv ../a.out ./a.out
+
+# Run
+./a.out | diff correct.txt -


### PR DESCRIPTION
Problem
On Ubuntu 22.04+ and other modern Linux distributions that default to Position Independent Executables (PIE), the ParaSail LLVM compiler bootstrap fails at the linking stage with relocation errors:
relocation R_X86_64_32 against `.rodata' can not be used when making a PIE object
This affects anyone attempting bin/pslc.csh -b3 on recent Debian/Ubuntu/Fedora systems.
Root Cause
Two places in the build pipeline were not PIE-aware:

bin/pslc.csh — clang -c was missing -fPIC, so object files were not position-independent
Makefile — the final link step was missing -no-pie, causing the linker to reject non-PIC objects

Fix

Add -fPIC to the clang -c step in bin/pslc.csh
Add -no-pie to MATHLIB in Makefile

Also included

Simplified compiler_llvm_tests/test_it.sh — replaced manual parasail_main invocation with pslc.csh -i -k, and collapsed 17 individual llc calls into a single pslc pass. Functionally equivalent, significantly more maintainable.

Verified on

Ubuntu 22.04 LTS (ThinkPad L470)
Full bootstrap via bin/pslc.csh -b3 -O2 
All 17 benchmark tests pass (./a.out | diff correct.txt - produces no output) 